### PR TITLE
chore: Package, Library, TargetModule 이름을 변경합니다. (PagecallCore)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,21 +4,21 @@
 import PackageDescription
 
 let package = Package(
-    name: "PagecallSDK",
+    name: "Pagecall",
     platforms: [
         .iOS(.v11)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "PagecallSDK",
-            targets: ["PagecallSDK", "AmazonChimeSDK", "AmazonChimeSDKMedia"])
+            name: "PagecallCore",
+            targets: ["PagecallCore", "AmazonChimeSDK", "AmazonChimeSDKMedia"])
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "PagecallSDK",
+            name: "PagecallCore",
             path: "Sources/PagecallSDK",
             resources: [
                 .process("PagecallNative.js")
@@ -31,5 +31,5 @@ let package = Package(
             path: "Binaries/AmazonChimeSDKMedia.xcframework"),
         .testTarget(
             name: "PagecallSDKTests",
-            dependencies: ["PagecallSDK"])
+            dependencies: ["PagecallCore"])
     ])

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ```swift
 import UIKit
 import WebKit
-import PagecallSDK
+import PagecallCore
 
 class ViewController: UIViewController, WKUIDelegate {
     var webView: PagecallWebView?

--- a/Tests/PagecallSDKTests/PagecallSDKTests.swift
+++ b/Tests/PagecallSDKTests/PagecallSDKTests.swift
@@ -1,11 +1,11 @@
+@testable import Pagecall
 import XCTest
-@testable import PagecallSDK
 
 final class PagecallSDKTests: XCTestCase {
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
         // results.
-        XCTAssertEqual(PagecallSDK().text, "Hello, World!")
+        XCTAssertEqual(Pagecall().text, "Hello, World!")
     }
 }


### PR DESCRIPTION
Pagecall App의 이름인 Pagecall과 Pagecall Legacy Sdk의 이름인 PagecallSDK를 피해 PagecallCore로 변경합니다.