### PR TITLE
fix: 1) use audioRecorder on demand, 2) cleanup chime observers

### DIFF
--- a/Sources/PagecallSDK/ChimeController.swift
+++ b/Sources/PagecallSDK/ChimeController.swift
@@ -76,6 +76,11 @@ class ChimeController {
             self.audioRecorder = audioRecorder
             audioRecorder.isMeteringEnabled = true
             audioRecorder.record()
+
+            audioRecorder.updateMeters()
+            let averagePower = audioRecorder.averagePower(forChannel: 0)
+            let nomalizedVolume = normalizeSoundLevel(level: averagePower)
+            callback(nomalizedVolume, nil)
         } catch {
             callback(nil, NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "AudioRecorder is not exist"]))
         }

--- a/Sources/PagecallSDK/ChimeController.swift
+++ b/Sources/PagecallSDK/ChimeController.swift
@@ -61,7 +61,7 @@ class ChimeController {
             let averagePower = audioRecorder.averagePower(forChannel: 0)
             let nomalizedVolume = normalizeSoundLevel(level: averagePower)
             callback(nomalizedVolume, nil)
-            return;
+            return
         }
         do {
             let documentPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
@@ -97,9 +97,9 @@ class ChimeController {
     }
 
     func stop(callback: (Error?) -> Void) {
-        if let audioRecorder = audioRecorder{
-            audioRecorder.stop();
-            self.audioRecorder = nil;
+        if let audioRecorder = audioRecorder {
+            audioRecorder.stop()
+            self.audioRecorder = nil
         }
         if let chimeMeetingSession = chimeMeetingSession {
             chimeMeetingSession.stop()

--- a/Sources/PagecallSDK/ChimeMeetingSession.swift
+++ b/Sources/PagecallSDK/ChimeMeetingSession.swift
@@ -11,14 +11,25 @@ import Foundation
 class ChimeMeetingSession {
     let meetingSession: DefaultMeetingSession
 
+    let realtimeObserver: ChimeRealtimeObserver
+    let audioVideoObserver: ChimeAudioVideoObserver
+    let metricsObserver: ChimeMetricsObserver
+    let deviceChangeObserver: ChimeDeviceChangeObserver
+
     init(configuration: MeetingSessionConfiguration, logger: AmazonChimeSDK.Logger, emitter: WebViewEmitter) {
         let meetingSession = DefaultMeetingSession(configuration: configuration, logger: logger)
         self.meetingSession = meetingSession
 
-        meetingSession.audioVideo.addRealtimeObserver(observer: ChimeRealtimeObserver(emitter: emitter, myAttendeeId: meetingSession.configuration.credentials.attendeeId))
-        meetingSession.audioVideo.addAudioVideoObserver(observer: ChimeAudioVideoObserver(emitter: emitter))
-        meetingSession.audioVideo.addMetricsObserver(observer: ChimeMetricsObserver(emitter: emitter))
-        meetingSession.audioVideo.addDeviceChangeObserver(observer: ChimeDeviceChangeObserver(emitter: emitter, meetingSession: self.meetingSession))
+        self.realtimeObserver = ChimeRealtimeObserver(emitter: emitter, myAttendeeId: meetingSession.configuration.credentials.attendeeId)
+        self.audioVideoObserver = ChimeAudioVideoObserver(emitter: emitter)
+        self.metricsObserver = ChimeMetricsObserver(emitter: emitter)
+        self.deviceChangeObserver = ChimeDeviceChangeObserver(emitter: emitter, meetingSession: self.meetingSession)
+
+        meetingSession.audioVideo.addRealtimeObserver(observer: realtimeObserver)
+        meetingSession.audioVideo.addAudioVideoObserver(observer: audioVideoObserver)
+        meetingSession.audioVideo.addMetricsObserver(observer: metricsObserver)
+        meetingSession.audioVideo.addDeviceChangeObserver(observer: deviceChangeObserver)
+
     }
 
     func start(callback: (Error?) -> Void) {
@@ -65,5 +76,10 @@ class ChimeMeetingSession {
 
     func dispose() {
         meetingSession.audioVideo.stop()
+
+        meetingSession.audioVideo.removeRealtimeObserver(observer: realtimeObserver)
+        meetingSession.audioVideo.removeAudioVideoObserver(observer: audioVideoObserver)
+        meetingSession.audioVideo.removeMetricsObserver(observer: metricsObserver)
+        meetingSession.audioVideo.removeDeviceChangeObserver(observer: deviceChangeObserver)
     }
 }

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -114,16 +114,14 @@ class NativeBridge {
             case .createSession:
                 if let payloadData = payload?.data(using: .utf8) {
                     self.chimeController.createMeetingSession(joinMeetingData: payloadData) { (error: Error?) in
-                        if let error = error { print("Failed to createMeetingSession: \(error.localizedDescription)") }
-                        else {
+                        if let error = error { print("Failed to createMeetingSession: \(error.localizedDescription)") } else {
                             self.response(requestId: requestId)
                         }
                     }
                 }
             case .start:
                 self.chimeController.start { (error: Error?) in
-                    if let error = error { print("Failed to start: \(error.localizedDescription)") }
-                    else {
+                    if let error = error { print("Failed to start: \(error.localizedDescription)") } else {
                         self.response(requestId: requestId)
                     }
                 }

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -26,7 +26,6 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
             configuration.limitsNavigationsToAppBoundDomains = true
         }
         super.init(frame: frame, configuration: configuration)
-        self.nativeBridge = .init(webview: self)
 
         self.allowsBackForwardNavigationGestures = false
 
@@ -56,6 +55,18 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
             }
         default:
             break
+        }
+    }
+
+    public override func didMoveToSuperview() {
+        if self.superview == nil {
+            self.nativeBridge?.disconnect()
+            self.nativeBridge = nil
+            return
+        }
+
+        if self.nativeBridge == nil {
+            self.nativeBridge = .init(webview: self)
         }
     }
 

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -3,22 +3,22 @@ import WebKit
 public class PagecallWebView: WKWebView, WKScriptMessageHandler {
     var nativeBridge: NativeBridge?
     var controllerName = "pagecall"
-    
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("PagecallSDK: PagecallWebView cannot be instantiated from a storyboard")
     }
-    
+
     override public init(frame: CGRect, configuration: WKWebViewConfiguration) {
         let contentController = WKUserContentController()
-        
+
         configuration.mediaTypesRequiringUserActionForPlayback = []
         configuration.allowsInlineMediaPlayback = true
         configuration.suppressesIncrementalRendering = false
         configuration.applicationNameForUserAgent = "PagecallIos"
         configuration.allowsAirPlayForMediaPlayback = true
         configuration.userContentController = contentController
-        
+
         if #available(iOS 13.0, *) {
             configuration.defaultWebpagePreferences.preferredContentMode = .mobile
         }
@@ -27,14 +27,14 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
         }
         super.init(frame: frame, configuration: configuration)
         self.nativeBridge = .init(webview: self)
-        
+
         self.allowsBackForwardNavigationGestures = false
-        
+
         if #available(iOS 15.0, *) {
             let osVersion = UIDevice.current.systemVersion
             self.customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/\(osVersion) Safari/605.1.15"
         }
-        
+
         if let path = Bundle.module.path(forResource: "PagecallNative", ofType: "js") {
             if let bindingJS = try? String(contentsOfFile: path, encoding: .utf8) {
                 let script = WKUserScript(source: bindingJS, injectionTime: .atDocumentStart, forMainFrameOnly: false)
@@ -44,10 +44,10 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
             NSLog("Failed to add PagecallNative script")
             return
         }
-        
+
         contentController.add(self, name: self.controllerName)
     }
-    
+
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         switch message.name {
         case self.controllerName:
@@ -58,7 +58,7 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
             break
         }
     }
-    
+
     public func dispose() {
         self.nativeBridge?.disconnect()
     }


### PR DESCRIPTION
1) use audioRecorder on demand
기존에는 audioRecorder.record() 가 ChimeController init 할때 미리 불리고 있었습니다.
PagecallWebView를 Pagecall room을 표시할때만 이용하는 사례에서는 문제가 없으나 일부 PagecallWebView를 Pagecall 이외의 목적으로도 사용하는 케이스에서 보안 이슈 및 부작용이 있을 수 있습니다.
따라서 audioRecorder.record() 를 꼭 필요할 때만 호출하도록 변경하였습니다.

2) cleanup chime observers
기존에는 PagecallWebView가 파괴되어도 메모리에서 release되지 않아서 계속 세션 연결이 유지되는 문제가 있었습니다.
원인을 파악해보니 addObserver로 Chime에 넘겨주는 emitter에서 webview를 계속 사용하고 있어서 발생하는 문제였습니다.
removeObserver를 제때 처리해주니 문제가 해결되었습니다.

