### PR TITLE
feat: dispose & init controller, deal with audio session

### DIFF
--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -13,7 +13,7 @@ enum BridgeEvent: String, Codable {
 }
 
 enum BridgeAction: String, Codable {
-    case createSession, initController, start, stop, getPermissions, requestPermission, pauseAudio, resumeAudio, getAudioDevices, setAudioDevice, requestAudioVolume, dispose
+    case createSession, `init`, start, stop, getPermissions, requestPermission, pauseAudio, resumeAudio, getAudioDevices, setAudioDevice, requestAudioVolume, dispose
 }
 
 struct ErrorEvent: Codable {
@@ -138,7 +138,7 @@ class NativeBridge {
                         }
                     }
                 }
-            case .initController:
+            case .`init`:
                 self.chimeController = .init(emitter: self.emitter)
                 self.response(requestId: requestId)
             case .start:

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -9,7 +9,7 @@ import Foundation
 import WebKit
 
 enum BridgeEvent: String, Codable {
-    case audioDevice, audioDevices, audioVolume, audioStatus, audioSessionRouteChanged, mediaStat, audioEnded, videoEnded, screenshareEnded, connected, disconnected, meetingEnded, log, error
+    case audioDevice, audioDevices, audioVolume, audioStatus, audioSessionRouteChanged, audioSessionInterrupted, mediaStat, audioEnded, videoEnded, screenshareEnded, connected, disconnected, meetingEnded, log, error
 }
 
 enum BridgeAction: String, Codable {

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -9,7 +9,7 @@ import Foundation
 import WebKit
 
 enum BridgeEvent: String, Codable {
-    case audioDevice, audioDevices, audioVolume, audioStatus, mediaStat, audioEnded, videoEnded, screenshareEnded, connected, disconnected, meetingEnded, log, error
+    case audioDevice, audioDevices, audioVolume, audioStatus, audioSessionRouteChanged, mediaStat, audioEnded, videoEnded, screenshareEnded, connected, disconnected, meetingEnded, log, error
 }
 
 enum BridgeAction: String, Codable {

--- a/Sources/js/src/PagecallNative.ts
+++ b/Sources/js/src/PagecallNative.ts
@@ -12,6 +12,11 @@ type PayloadByNativeEvent = {
   audioDevices: MediaDeviceInfo[];
   audioVolume: number;
   audioStatus: { sessionId: string; muted: boolean };
+  audioSessionRouteChanged: {
+    reason: string;
+    outputs: { portType: string; portName: string; uid: string }[];
+    category: string;
+  };
   mediaStat: MediaStat;
   audioEnded: void;
   videoEnded: void;

--- a/Sources/js/src/PagecallNative.ts
+++ b/Sources/js/src/PagecallNative.ts
@@ -17,6 +17,11 @@ type PayloadByNativeEvent = {
     outputs: { portType: string; portName: string; uid: string }[];
     category: string;
   };
+  audioSessionInterrupted: {
+    reason: "Default" | "BuiltInMicMuted" | "Unknown" | "None";
+    type: "Began" | "Ended" | "Unknown" | "None";
+    options: "ShouldResume" | "Unknown" | "None";
+  }
   mediaStat: MediaStat;
   audioEnded: void;
   videoEnded: void;


### PR DESCRIPTION
- coreapp 에서 ChimeController 를 dispose 할 수 있습니다.
- coreapp 에서 ChimeController 를 init 할 수 있습니다. (initController)
- audioSession.setCategory 에 추가적인 옵션을 부여합니다. 안정적인 음성 송수신을 보장할 것으로 기대합니다.
- AudioSessionRouteChange 될 때 마다 audioSession.setCategory를 새로 해주고 coreapp에 audioSessionRouteChanged 이벤트를 전달합니다. Chime SDK 자체적인 기기 변경 이벤트로는 감지하지 못하지만 audioSessionRouteChanged 이벤트로는 감지할 수 있는 상황이 있기를 기대합니다.
- 위와 같은 목적으로 audioSessionInterrupted 이벤트를 coreapp에 전달합니다.

테스트

pagecall-ios 앱에 적용하여 정상 작동과 registerListener("audioSessionRouteChanged" | "audioSessionInterrupted", ...) 테스트 완료