### PR TITLE
fix: chimeController dispose & removeScriptMessageHandler

### DIFF
--- a/Sources/PagecallSDK/ChimeController.swift
+++ b/Sources/PagecallSDK/ChimeController.swift
@@ -402,16 +402,14 @@ class ChimeController {
     func dispose(callback: (Error?) -> Void) {
         NotificationCenter.default.removeObserver(self)
 
-        if self.audioRecorder != nil && self.chimeMeetingSession != nil {
-            audioRecorder?.stop()
+        if let audioRecorder = self.audioRecorder {
+            audioRecorder.stop()
             self.audioRecorder = nil
-
-            chimeMeetingSession?.dispose()
-            self.chimeMeetingSession = nil
-
-            callback(nil)
-        } else {
-            callback(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "chimeMeetingSession and audioRecorder not exist"]))
         }
+        if let chimeMeetingSession = self.chimeMeetingSession {
+            chimeMeetingSession.dispose()
+            self.chimeMeetingSession = nil
+        }
+        callback(nil)
     }
 }

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -3,6 +3,7 @@ import WebKit
 public class PagecallWebView: WKWebView, WKScriptMessageHandler {
     var nativeBridge: NativeBridge?
     var controllerName = "pagecall"
+    let contentController = WKUserContentController()
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
@@ -10,7 +11,6 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
     }
 
     override public init(frame: CGRect, configuration: WKWebViewConfiguration) {
-        let contentController = WKUserContentController()
 
         configuration.mediaTypesRequiringUserActionForPlayback = []
         configuration.allowsInlineMediaPlayback = true
@@ -60,8 +60,7 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
 
     public override func didMoveToSuperview() {
         if self.superview == nil {
-            self.nativeBridge?.disconnect()
-            self.nativeBridge = nil
+            self.dispose()
             return
         }
 
@@ -72,5 +71,7 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
 
     public func dispose() {
         self.nativeBridge?.disconnect()
+        self.nativeBridge = nil
+        self.contentController.removeScriptMessageHandler(forName: self.controllerName)
     }
 }

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -60,7 +60,7 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
 
     public override func didMoveToSuperview() {
         if self.superview == nil {
-            self.dispose()
+            self.disposeInner()
             return
         }
 
@@ -69,9 +69,13 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
         }
     }
 
-    public func dispose() {
+    private func disposeInner() {
         self.nativeBridge?.disconnect()
         self.nativeBridge = nil
         self.contentController.removeScriptMessageHandler(forName: self.controllerName)
+    }
+
+    public func dispose() {
+        self.disposeInner()
     }
 }


### PR DESCRIPTION
- ChimeController.dispose 에서 audioRecord 와 chimeMeetingSession이 둘다 존재해야지만 dispose가 정상적으로 수행되는 문제가 있었습니다.
- audioRecord는 없더라도 chimeMeetingSession는 있을 수 있어서 chimeMeetingSession이 정리되어야했음에도 정리가 안되는 문제가 있었습니다.
- 따라서 audioRecord, chimeMeetingSession 각각의 존재 여부를 따로 체크해서 dispose 작업을 수행합니다.

- PagecallWebView dispose시에 contentController.removeScriptMessageHandler 처리합니다.

@js-seo 참고로 해당 작업 이후에도 flutter_inappwebview 에서의 GC 누락 문제는 해결되지 않았습니다.