### PR TITLE
sendMessage, listenMessage 지원

### DIFF
--- a/Sources/PagecallSDK/PagecallView.swift
+++ b/Sources/PagecallSDK/PagecallView.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 
 public struct PagecallView: UIViewControllerRepresentable, PagecallDelegate {
+    public func pagecallDidReceive(_ controller: PagecallWebViewController, message: String) {
+        onMessage?(message)
+    }
+
     public func pagecallDidLoad(_ controller: PagecallWebViewController) {
         onLoad?()
     }
@@ -17,16 +21,18 @@ public struct PagecallView: UIViewControllerRepresentable, PagecallDelegate {
     let onLoad: (() -> Void)?
     let onClose: (() -> Void)?
     let onDownloadRequest: ((URL) -> Void)?
+    let onMessage: ((String) -> Void)?
 
     public init(url: URL) {
-        self.init(url: url, onLoad: nil, onClose: nil, onDownloadRequest: nil)
+        self.init(url: url, onLoad: nil, onClose: nil, onDownloadRequest: nil, onMessage: nil)
     }
 
-    public init(url: URL, onLoad: (() -> Void)?, onClose: (() -> Void)?, onDownloadRequest: ((URL) -> Void)?) {
+    public init(url: URL, onLoad: (() -> Void)?, onClose: (() -> Void)?, onDownloadRequest: ((URL) -> Void)?, onMessage: ((String) -> Void)?) {
         self.url = url
         self.onLoad = onLoad
         self.onClose = onClose
         self.onDownloadRequest = onDownloadRequest
+        self.onMessage = onMessage
     }
 
     public func makeUIViewController(context: Context) -> some UIViewController {

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -35,60 +35,151 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
         self.init(frame: .zero, configuration: .init())
     }
 
-    override public init(frame: CGRect, configuration: WKWebViewConfiguration) {
+    var scriptPath = {
+        #if SWIFT_PACKAGE
+        return Bundle.module.path(forResource: "PagecallNative", ofType: "js")
+        #else
+        return Bundle.init(for: Self.self).path(forResource: "PagecallNative", ofType: "js")
+        #endif
+    }()
 
+    var safariUserAgent: String = {
+        let webkitVersion = "605.1.15"
+        let systemVersion = UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")
+
+        let systemFragment = UIDevice.current.userInterfaceIdiom == .phone ?
+            "Mozilla/5.0 (iPhone; CPU iPhone OS \(systemVersion) like Mac OS X)"
+            : "Mozilla/5.0 (Macintosh; Intel Mac OS X \(systemVersion))"
+        let webkitFragment = "AppleWebKit/\(webkitVersion) (KHTML, like Gecko)"
+        let versionFragment = "Version/\(systemVersion)"
+        let browserFragment = "Safari/\(webkitVersion)"
+
+        return [systemFragment, webkitFragment, versionFragment, browserFragment].joined(separator: " ")
+    }()
+
+    override public init(frame: CGRect, configuration: WKWebViewConfiguration) {
         configuration.mediaTypesRequiringUserActionForPlayback = []
         configuration.allowsInlineMediaPlayback = true
         configuration.suppressesIncrementalRendering = false
         configuration.applicationNameForUserAgent = "PagecallIos"
         configuration.allowsAirPlayForMediaPlayback = true
+        configuration.defaultWebpagePreferences.preferredContentMode = .mobile
+        configuration.limitsNavigationsToAppBoundDomains = true
 
-        if #available(iOS 13.0, *) {
-            configuration.defaultWebpagePreferences.preferredContentMode = .mobile
+        if let scriptPath = scriptPath, let bindingJS = try? String(contentsOfFile: scriptPath, encoding: .utf8) {
+            let script = WKUserScript(source: bindingJS, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            configuration.userContentController.addUserScript(script)
+        } else {
+            print("[PagecallWebView] Failed to add PagecallNative script")
         }
-        if #available(iOS 14.0, *) {
-            configuration.limitsNavigationsToAppBoundDomains = true
-        }
+
         super.init(frame: frame, configuration: configuration)
-
         self.allowsBackForwardNavigationGestures = false
-
-        if #available(iOS 15.0, *) {
-            let osVersion = UIDevice.current.systemVersion
-            self.customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/\(osVersion) Safari/605.1.15"
-        }
-        #if SWIFT_PACKAGE
-        if let path = Bundle.module.path(forResource: "PagecallNative", ofType: "js") {
-            if let bindingJS = try? String(contentsOfFile: path, encoding: .utf8) {
-                let script = WKUserScript(source: bindingJS, injectionTime: .atDocumentStart, forMainFrameOnly: false)
-                configuration.userContentController.addUserScript(script)
-            }
-        } else {
-            NSLog("Failed to add PagecallNative script")
-            return
-        }
-        #else
-        if let path = Bundle.init(for: Self.self).path(forResource: "PagecallNative", ofType: "js") {
-            if let bindingJS = try? String(contentsOfFile: path, encoding: .utf8) {
-                let script = WKUserScript(source: bindingJS, injectionTime: .atDocumentStart, forMainFrameOnly: false)
-                configuration.userContentController.addUserScript(script)
-            }
-        } else {
-            NSLog("Failed to add PagecallNative script")
-            return
-        }
-        #endif
+        self.customUserAgent = safariUserAgent
         configuration.userContentController.add(LeakAvoider(delegate: self), name: self.controllerName)
     }
 
+    private var callbacks = [String: (Any?) -> Void]()
+    public func getReturnValue(script: String, completion: @escaping (Any?) -> Void) {
+        let id = UUID().uuidString
+        callbacks[id] = completion
+        let returningScript =
+            """
+const callback = (value) => {
+  window.webkit.messageHandlers.\(controllerName).postMessage({
+    type: "return",
+    payload: {
+      id: "\(id)",
+      value
+    }
+  });
+}
+const result = \(script);
+
+if (result.then) {
+  result.then(callback);
+} else {
+  callback(result);
+}
+"""
+        evaluateJavascriptWithLog(script: returningScript)
+    }
+
+    private var subscribers = [String: (Any?) -> Void]()
+    private let subscriptionsStorageName = "__pagecallNativeSubscriptions"
+    public func subscribe(target: String, subscriber: @escaping (Any?) -> Void) -> () -> Void {
+        let id = UUID().uuidString
+        subscribers[id] = subscriber
+        let returningScript =
+            """
+const callback = (value) => {
+  window.webkit.messageHandlers.\(controllerName).postMessage({
+    type: "subscription",
+    payload: {
+      id: "\(id)",
+      value
+    }
+  });
+}
+const subscription = \(target).subscribe(callback);
+if (!window["\(subscriptionsStorageName)"]) window["\(subscriptionsStorageName)"] = {};
+window["\(subscriptionsStorageName)"]["\(id)"] = subscription;
+"""
+        evaluateJavascriptWithLog(script: returningScript)
+        return {
+            self.evaluateJavascriptWithLog(script: """
+window["\(self.subscriptionsStorageName)"][\(id)]?.unsubscribe();
+""")
+            self.subscribers.removeValue(forKey: id)
+        }
+    }
+
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        switch message.name {
-        case self.controllerName:
-            if let body = message.body as? String {
-                self.nativeBridge?.messageHandler(message: body)
+        guard message.name == self.controllerName else { return }
+        if let body = message.body as? [String: Any] {
+            guard let type = body["type"] as? String, let payload = body["payload"] as? [String: Any], let id = payload["id"] as? String else { return }
+            switch type {
+            case "return":
+                guard let callback = callbacks[id] else { return }
+                callbacks.removeValue(forKey: id)
+                callback(payload["value"])
+            case "subscription":
+                guard let subscriber = subscribers[id] else { return }
+                subscriber(payload["value"])
+            default:
+                print("[PagecallWebView] Unknown message type: \(type)")
             }
-        default:
-            break
+            return
+        } else if let body = message.body as? String {
+            self.nativeBridge?.messageHandler(message: body)
+        }
+    }
+
+    public func sendMessage(message: String, completionHandler: ((Error?) -> Void)?) {
+        evaluateJavascriptWithLog(script:
+"""
+if (!window.Pagecall) return false;
+window.Pagecall.sendMessage("\(message.javaScriptString)");
+return true;
+"""
+        ) { result, error in
+            if let error {
+                completionHandler?(error)
+            } else if let success = result as? Bool, success {
+                completionHandler?(nil)
+            } else {
+                completionHandler?(PagecallError(message: "Not initialized"))
+            }
+        }
+    }
+
+    public func listenMessage(subscriber: @escaping (String) -> Void) -> () -> Void {
+        return subscribe(target: "PagecallUI.customMessage$") { payload in
+            if let payload = payload as? String {
+                subscriber(payload)
+            } else {
+                print("[PagecallWebView] Invalid or unsupported message")
+            }
         }
     }
 

--- a/Sources/PagecallSDK/PagecallWebViewController.swift
+++ b/Sources/PagecallSDK/PagecallWebViewController.swift
@@ -4,31 +4,17 @@ import WebKit
 public protocol PagecallDelegate {
     func pagecallDidClose(_ controller: PagecallWebViewController)
     func pagecallDidLoad(_ controller: PagecallWebViewController)
+    func pagecallDidReceive(_ controller: PagecallWebViewController, message: String)
     func pagecall(_ controller: PagecallWebViewController, requestDownloadFor url: URL)
 }
 
 public class PagecallWebViewController:
-    UIViewController, WKUIDelegate, WKScriptMessageHandler, WKNavigationDelegate, UIPencilInteractionDelegate {
-    private var webView: PagecallWebView!
-    private let bridgeName = "pagecallController"
+    UIViewController, WKUIDelegate, WKNavigationDelegate, UIPencilInteractionDelegate {
+    private let webView = PagecallWebView()
 
     public var delegate: PagecallDelegate?
 
     public var isPenInteractionEnabled = false
-
-    private var userAgent: String {
-        let webkitVersion = "605.1.15"
-        let systemVersion = UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")
-
-        let systemFragment = UIDevice.current.userInterfaceIdiom == .phone ?
-            "Mozilla/5.0 (iPhone; CPU iPhone OS \(systemVersion) like Mac OS X)"
-            : "Mozilla/5.0 (Macintosh; Intel Mac OS X \(systemVersion))"
-        let webkitFragment = "AppleWebKit/\(webkitVersion) (KHTML, like Gecko)"
-        let versionFragment = "Version/\(systemVersion)"
-        let browserFragment = "Safari/\(webkitVersion)"
-
-        return [systemFragment, webkitFragment, versionFragment, browserFragment].joined(separator: " ")
-    }
 
     convenience public init() {
         self.init(customUserAgent: nil)
@@ -37,28 +23,18 @@ public class PagecallWebViewController:
     public init(customUserAgent: String?) {
         super.init(nibName: nil, bundle: nil)
 
-        let configuration = WKWebViewConfiguration()
-        configuration.userContentController.add(LeakAvoider(delegate: self), name: bridgeName)
-        configuration.limitsNavigationsToAppBoundDomains = true
-        configuration.allowsInlineMediaPlayback = true
-        webView = PagecallWebView(frame: .zero, configuration: configuration)
         webView.scrollView.contentInsetAdjustmentBehavior = .never
 
         webView.uiDelegate = self
         webView.navigationDelegate = self
 
-        webView.allowsBackForwardNavigationGestures = false
-        webView.customUserAgent = [userAgent, "PagecallSDK", "PagecallWebViewController", customUserAgent].compactMap { $0 }.joined(separator: " ")
+        webView.customUserAgent = [webView.customUserAgent, "PagecallSDK", "PagecallWebViewController", customUserAgent].compactMap { $0 }.joined(separator: " ")
 
         let interaction = UIPencilInteraction()
         interaction.delegate = self
         webView.addInteraction(interaction)
 
         view.addSubview(webView)
-    }
-
-    public func load(_ url: URL) {
-        self.webView.load(URLRequest(url: url))
     }
 
     required init?(coder: NSCoder) {
@@ -76,7 +52,7 @@ public class PagecallWebViewController:
     }
 
     private func toggleToolMode() {
-        self.getReturnValue(script: """
+        webView.getReturnValue(script: """
     (function() {
       let toolMode
       const subscription = Pagecall.canvas.toolMode$.subscribe((mode) => {
@@ -95,90 +71,6 @@ public class PagecallWebViewController:
         }
     }
 
-    private func getReturnValue(script: String, completion: @escaping (Any?) -> Void) {
-        let id = UUID().uuidString
-        callbacks[id] = completion
-        let returningScript =
-            """
-const callback = (value) => {
-  window.webkit.messageHandlers.\(bridgeName).postMessage({
-    type: "return",
-    payload: {
-      id: "\(id)",
-      value
-    }
-  });
-}
-const result = \(script);
-
-if (result.then) {
-  result.then(callback);
-} else {
-  callback(result);
-}
-"""
-        webView.evaluateJavascriptWithLog(script: returningScript)
-    }
-
-    var callbacks = [String: (Any?) -> Void]()
-    var subscribers = [String: (Any?) -> Void]()
-
-    let subscriptionsStorageName = "__pagecallNativeSubscriptions"
-    public func subscribe(target: String, subscriber: @escaping (Any?) -> Void) -> () -> Void {
-        let id = UUID().uuidString
-        subscribers[id] = subscriber
-        let returningScript =
-            """
-const callback = (value) => {
-  window.webkit.messageHandlers.\(bridgeName).postMessage({
-    type: "subscription",
-    payload: {
-      id: "\(id)",
-      value
-    }
-  });
-}
-const subscription = \(target).subscribe(callback);
-if (!window["\(subscriptionsStorageName)"]) window["\(subscriptionsStorageName)"] = {};
-window["\(subscriptionsStorageName)"]["\(id)"] = subscription;
-"""
-        webView.evaluateJavascriptWithLog(script: returningScript)
-        return {
-            self.webView.evaluateJavascriptWithLog(script: """
-window["\(self.subscriptionsStorageName)"][\(id)]?.unsubscribe();
-""")
-            self.subscribers.removeValue(forKey: id)
-        }
-    }
-
-    public func sendMessage(message: String, completionHandler: ((Error?) -> Void)?) {
-        webView.evaluateJavascriptWithLog(script:
-"""
-if (!window.Pagecall) return false;
-window.Pagecall.sendMessage("\(message.javaScriptString)");
-return true;
-"""
-        ) { result, error in
-            if let error {
-                completionHandler?(error)
-            } else if let success = result as? Bool, success {
-                completionHandler?(nil)
-            } else {
-                completionHandler?(PagecallError(message: "Not initialized"))
-            }
-        }
-    }
-
-    public func listenMessage(subscriber: @escaping (String) -> Void) -> () -> Void {
-        return subscribe(target: "PagecallUI.customMessage$") { payload in
-            if let payload = payload as? String {
-                subscriber(payload)
-            } else {
-                print("[PagecallWebViewController] Invalid or unsupported message")
-            }
-        }
-    }
-
     // MARK: - WKUIDelegate
     @available(iOS 15.0, *)
     public func webView(
@@ -189,25 +81,6 @@ return true;
         decisionHandler: @escaping (WKPermissionDecision) -> Void
     ) {
         decisionHandler(.grant)
-    }
-
-    // MARK: - WKScriptMessageHandler
-    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        webView.userContentController(userContentController, didReceive: message)
-        guard message.name == bridgeName else { return }
-        guard let body = message.body as? [String: Any] else { return }
-        guard let type = body["type"] as? String, let payload = body["payload"] as? [String: Any] else { return }
-        if type == "return" {
-            if let id = payload["id"] as? String, let callback = callbacks[id] {
-                callbacks.removeValue(forKey: id)
-                callback(payload["value"])
-            }
-        }
-        if type == "subscription" {
-            if let id = payload["id"] as? String, let subscriber = subscribers[id] {
-                subscriber(payload["value"])
-            }
-        }
     }
 
     // MARK: - WKNavigationDelegate
@@ -247,8 +120,11 @@ return true;
         decisionHandler(.allow)
     }
 
+    var messageUnsubscriber: (() -> Void)?
+
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        self.getReturnValue(script: """
+        guard let webView = webView as? PagecallWebView else { return }
+        webView.getReturnValue(script: """
 function() {
     let trialCount = 0;
     function waitForLoad() {
@@ -269,7 +145,7 @@ function() {
     return waitForLoad();
 }()
 """) { _ in
-            self.webView.evaluateJavascriptWithLog(script: """
+            webView.evaluateJavascriptWithLog(script: """
 window.PagecallUI.get$('terminationState').subscribe((state) => {
     if (!state) return;
     if (state.state === "error" || state.state === "emptyReplay") {
@@ -279,7 +155,7 @@ window.PagecallUI.get$('terminationState').subscribe((state) => {
     }
 });
 """)
-            self.getReturnValue(script: """
+            webView.getReturnValue(script: """
 new Promise((resolve) => {
     const subscription = window.PagecallUI.controller$.subscribe((controller) => {
         if (!controller) return;
@@ -289,16 +165,16 @@ new Promise((resolve) => {
 })
 """) { _ in
                 self.delegate?.pagecallDidLoad(self)
+                self.messageUnsubscriber?()
+                self.messageUnsubscriber = webView.listenMessage(subscriber: { message in
+                    self.delegate?.pagecallDidReceive(self, message: message)
+                })
             }
         }
     }
 
     public func webViewDidClose(_ webView: WKWebView) {
         self.delegate?.pagecallDidClose(self)
-    }
-
-    deinit {
-        self.webView.configuration.userContentController.removeScriptMessageHandler(forName: bridgeName)
     }
 
     // MARK: - UIPencilInteractionDelegate
@@ -308,6 +184,19 @@ new Promise((resolve) => {
     }
 
     var downloadedPreviewItemUrl: URL?
+
+    // MARK: Public methods
+    public func load(_ url: URL) {
+        self.webView.load(URLRequest(url: url))
+    }
+
+    public func sendMessage(_ message: String) {
+        sendMessage(message, completionHandler: nil)
+    }
+
+    public func sendMessage(_ message: String, completionHandler: ((Error?) -> Void)?) {
+        webView.sendMessage(message: message, completionHandler: completionHandler)
+    }
 }
 
 @available(iOS 14.5, *)

--- a/Sources/PagecallSDK/PagecallWebViewController.swift
+++ b/Sources/PagecallSDK/PagecallWebViewController.swift
@@ -8,6 +8,13 @@ public protocol PagecallDelegate {
     func pagecall(_ controller: PagecallWebViewController, requestDownloadFor url: URL)
 }
 
+// Optional delegates
+public extension PagecallDelegate {
+    func pagecallDidLoad(_ controller: PagecallWebViewController) {}
+    func pagecallDidReceive(_ controller: PagecallWebViewController, message: String) {}
+    func pagecall(_ controller: PagecallWebViewController, requestDownloadFor url: URL) {}
+}
+
 public class PagecallWebViewController:
     UIViewController, WKUIDelegate, WKNavigationDelegate, UIPencilInteractionDelegate {
     private let webView = PagecallWebView()


### PR DESCRIPTION
https://github.com/pplink/pagecall/pull/2978 가 배포되어야 정상작동합니다. `9c0cede` 빌드를 이용해 사전 테스트를 해보실 수 있습니다.

## `PagecallWebViewController`로 이용하기 (권장)

- `PagecallWebViewController`에 `sendMessage(_ message: String)` 메서드가 추가되었습니다.
- `PagecallDelegate`에 `pagecallDidReceive(_ controller:PagecallWebViewController, message: String)` delegate 메서드가 추가되었습니다.

### Working example
<img width="654" alt="스크린샷 2023-04-18 오후 6 57 38" src="https://user-images.githubusercontent.com/19246445/232742389-66c15d19-f6d3-4c9b-b80d-ae1cd562bb8b.png">

```swift
import UIKit
import PagecallCore

struct EmojiMessage: Codable {
    let emoji: String
    let sender: String
}

class ViewController: UIViewController, PagecallDelegate {
    func pagecallDidReceive(_ controller: PagecallCore.PagecallWebViewController, message: String) {
        do {
            let decoded = try JSONDecoder().decode(EmojiMessage.self, from: message.data(using: .utf8)!)
            self.showTextForDuration(text: "\(decoded.sender) has sent: \(decoded.emoji)", duration: 5)
        } catch {
            print("Failed to decode", message)
        }
    }
    
    func pagecallDidClose(_ controller: PagecallCore.PagecallWebViewController) {
        self.dismiss(animated: true)
    }
    
    var pagecallWebViewController: PagecallWebViewController!
    
    override func viewDidLoad() {
        super.viewDidLoad()
    
        let button = UIButton(type: .system)
        button.setTitle("Send emoji!", for: .normal)
        button.frame = CGRect(x: 100, y: 100, width: 200, height: 40)
        button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
        view.addSubview(button)
        
        button.translatesAutoresizingMaskIntoConstraints = false
        let centerXConstraint = NSLayoutConstraint(item: button, attribute: .centerX, relatedBy: .equal, toItem: view, attribute: .centerX, multiplier: 1.0, constant: 0)
        view.addConstraint(centerXConstraint)
        NSLayoutConstraint.activate([
            button.heightAnchor.constraint(greaterThanOrEqualToConstant: 80),
            button.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 0)
        ])
        
        pagecallWebViewController = PagecallWebViewController()
        pagecallWebViewController.delegate = self
        view.addSubview(pagecallWebViewController.view)
        pagecallWebViewController.view.translatesAutoresizingMaskIntoConstraints = false
        NSLayoutConstraint.activate([
            pagecallWebViewController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
            pagecallWebViewController.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
            pagecallWebViewController.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
            pagecallWebViewController.view.bottomAnchor.constraint(equalTo: button.topAnchor, constant: 20)
        ])

        self.addChild(pagecallWebViewController)
        pagecallWebViewController.didMove(toParent: self)
        
        pagecallWebViewController.load(URL(string: "https://app.pagecall.com/meet?room_id=642bf7e398446d58380fd78c&build=e3c38c6")!)
    }
    
    @objc func buttonTapped(_ sender: Any) {
        let emojis = ["😍", "😈", "👻"]
        let senders = ["Frodo", "Samwise", "Merry", "Pippin"]
        let message = EmojiMessage(emoji: emojis.randomElement()!, sender: senders.randomElement()!)
        let jsonData = try! JSONEncoder().encode(message)
        let jsonString = String(data: jsonData, encoding: .utf8)!
        pagecallWebViewController.sendMessage(jsonString) { error in
            if let error = error {
                print("Failed to send", error)
            } else {
                print("Successfully sent")
            }
        }
    }
    
    func showTextForDuration(text: String, duration: TimeInterval) {
        let label = UILabel()
        label.text = text
        label.textAlignment = .center
        label.backgroundColor = .black
        label.textColor = .white
        label.alpha = 0.0
        label.translatesAutoresizingMaskIntoConstraints = false
        view.addSubview(label)
        
        NSLayoutConstraint.activate([
            label.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: 0),
            label.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 0)
        ])
        
        UIView.animate(withDuration: 0.5, animations: {
            label.alpha = 1.0
        }) { (_) in
            DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: {
                UIView.animate(withDuration: 0.5, animations: {
                    label.alpha = 0.0
                }, completion: { (_) in
                    label.removeFromSuperview()
                })
            })
        }
    }
}
```


## `PagecallWebView`로 이용하기
- `sendMessage`로 메시지를 보낼 수 있습니다. 초기화 완료 후에만 동작합니다. (입장페이지 이후)
- `listenMessage`로 메시지를 받을 수 있습니다. 역시 초기화 완료 후에만 동작합니다. (입장페이지 이후)
  - 리턴되는 함수는 구독을 중단하는 것입니다. 중복으로 처리되는 것을 피하려면 새로운 구독을 만들기 전 이전 구독을 취소하셔야 합니다.