### PR TITLE
공식 cocoapod repo 에 업로드를 위해 LICENSE 를 추가하고 podspec 버전을 변경합니다.

### DIFF
--- a/Pagecall.podspec
+++ b/Pagecall.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Pagecall'
-  s.version          = '0.1.0'
+  s.version          = '0.0.4'
   s.summary          = 'Pagecall WebView: Enhanced Voice Communication via Custom WebView based on WKWebView'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
공식 pod repo 에 업로드하기 위해서는 LICENSE 가 필요합니다. 
  - 파일이 없을때 경고를 무시하고 강제로 업로드가 가능하지만 이러면 매번 강제 업로드 옵션을 켜줘야합니다.
 
버저닝이 지금 0.0.3 있기때문에 podspec 에는 0.0.4 로 변경합니다.
  - 0.0.4 태그를 추가해야합니다.