### PR TITLE
flutter webview 대응

### DIFF
--- a/Pagecall.podspec
+++ b/Pagecall.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.vendored_frameworks =  [
     'Binaries/AmazonChimeSDK.xcframework',
-    'Binaries/AmazonChimeSDKMedia.xcframework', 
+    'Binaries/AmazonChimeSDKMedia.xcframework',
     'Binaries/Mediasoup.xcframework',
     'Binaries/WebRTC.xcframework'
     ]

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -58,13 +58,14 @@ open class PagecallWebView: WKWebView, WKScriptMessageHandler {
         configuration.defaultWebpagePreferences.preferredContentMode = .mobile
         configuration.limitsNavigationsToAppBoundDomains = true
 
-        if let scriptPath = {
+        let bundle = {
 #if SWIFT_PACKAGE
-            return Bundle.module.path(forResource: "PagecallNative", ofType: "js")
+            return Bundle.module
 #else
-            return Bundle.init(for: Self.self).path(forResource: "PagecallNative", ofType: "js")
+            return Bundle.init(for: PagecallWebView.self)
 #endif
-        }(), let bindingJS = try? String(contentsOfFile: scriptPath, encoding: .utf8) {
+        }()
+        if let scriptPath = bundle.path(forResource: "PagecallNative", ofType: "js"), let bindingJS = try? String(contentsOfFile: scriptPath, encoding: .utf8) {
             let script = WKUserScript(source: bindingJS, injectionTime: .atDocumentStart, forMainFrameOnly: false)
             configuration.userContentController.addUserScript(script)
         } else {

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -22,26 +22,18 @@ extension WKWebView {
     }
 }
 
-public class PagecallWebView: WKWebView, WKScriptMessageHandler {
+open class PagecallWebView: WKWebView, WKScriptMessageHandler {
     var nativeBridge: NativeBridge?
     var controllerName = "pagecall"
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) {
+    required public init?(coder: NSCoder) {
         fatalError("PagecallSDK: PagecallWebView cannot be instantiated from a storyboard")
     }
 
     convenience public init() {
         self.init(frame: .zero, configuration: .init())
     }
-
-    var scriptPath = {
-        #if SWIFT_PACKAGE
-        return Bundle.module.path(forResource: "PagecallNative", ofType: "js")
-        #else
-        return Bundle.init(for: Self.self).path(forResource: "PagecallNative", ofType: "js")
-        #endif
-    }()
 
     var safariUserAgent: String = {
         let webkitVersion = "605.1.15"
@@ -66,7 +58,13 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
         configuration.defaultWebpagePreferences.preferredContentMode = .mobile
         configuration.limitsNavigationsToAppBoundDomains = true
 
-        if let scriptPath = scriptPath, let bindingJS = try? String(contentsOfFile: scriptPath, encoding: .utf8) {
+        if let scriptPath = {
+#if SWIFT_PACKAGE
+            return Bundle.module.path(forResource: "PagecallNative", ofType: "js")
+#else
+            return Bundle.init(for: Self.self).path(forResource: "PagecallNative", ofType: "js")
+#endif
+        }(), let bindingJS = try? String(contentsOfFile: scriptPath, encoding: .utf8) {
             let script = WKUserScript(source: bindingJS, injectionTime: .atDocumentStart, forMainFrameOnly: false)
             configuration.userContentController.addUserScript(script)
         } else {
@@ -134,7 +132,7 @@ window["\(self.subscriptionsStorageName)"][\(id)]?.unsubscribe();
         }
     }
 
-    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    open func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard message.name == self.controllerName else { return }
         if let body = message.body as? [String: Any] {
             guard let type = body["type"] as? String, let payload = body["payload"] as? [String: Any], let id = payload["id"] as? String else { return }
@@ -204,11 +202,11 @@ return true;
         self.configuration.userContentController.removeScriptMessageHandler(forName: self.controllerName)
     }
 
-    public func dispose() {
-        self.disposeInner()
+    open func dispose() {
+        disposeInner()
     }
 
     deinit {
-        dispose()
+        disposeInner()
     }
 }

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -75,6 +75,8 @@ open class PagecallWebView: WKWebView, WKScriptMessageHandler {
         super.init(frame: frame, configuration: configuration)
         self.allowsBackForwardNavigationGestures = false
         self.customUserAgent = safariUserAgent
+        // Some environments, such as flutter_inappwebview, reuse the configuration and it is not allowed to add a handler with the same name
+        configuration.userContentController.removeScriptMessageHandler(forName: self.controllerName)
         configuration.userContentController.add(LeakAvoider(delegate: self), name: self.controllerName)
     }
 


### PR DESCRIPTION
- 일부 메서드를 오버라이드 할 수 있게 열어둡니다. 42b6df04f45d8746b7fcab7fc6adc9e60c0fc1d1
- `Self.self`로 번들을 찾는 경우 호스트 프로젝트로 연결되는 현상이 있어 `PagecallWebView`를 명시적으로 이용해 js 파일을 올바르게 찾도록 합니다. d823b4d1df5a0bae5646c8a9ab7b4f36a087a423
- `flutter_inappwebview`에서는 configuration을 재활용하는데 이 때 오류가 발생하지 않도록 처리합니다. d0e7de9168046b3180db3042ed4180357e5e035c