### PR TITLE
콜킷 적용 (#18) 후 오류 해결

### DIFF
--- a/Pagecall.podspec
+++ b/Pagecall.podspec
@@ -38,6 +38,6 @@ Pod::Spec.new do |s|
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.5.0'
+  s.dependency 'Sentry', '8.5.0'
 
 end

--- a/Sources/PagecallSDK/ChimeAudioVideoObserver.swift
+++ b/Sources/PagecallSDK/ChimeAudioVideoObserver.swift
@@ -18,7 +18,7 @@ class ChimeAudioVideoObserver: AudioVideoObserver {
     func audioSessionDidDrop() {}
 
     func audioSessionDidStopWithStatus(sessionStatus: MeetingSessionStatus) {
-        self.emitter.emit(eventName: .disconnected, json: ["statusCode": sessionStatus.statusCode])
+        self.emitter.emit(eventName: .disconnected, json: ["statusCode": sessionStatus.statusCode.rawValue])
     }
 
     func audioSessionDidCancelReconnect() {}

--- a/Sources/PagecallSDK/ChimeController.swift
+++ b/Sources/PagecallSDK/ChimeController.swift
@@ -123,4 +123,17 @@ class ChimeController: MediaController {
     deinit {
         dispose()
     }
+
+    private var volumeRecorder: VolumeRecorder?
+    func getAudioVolume() -> Float {
+        if let volumeRecorder = volumeRecorder {
+            return volumeRecorder.requestAudioVolume()
+        } else {
+            let volumeRecorder = try! VolumeRecorder()
+            volumeRecorder.highest = -10
+            volumeRecorder.lowest = -40
+            self.volumeRecorder = volumeRecorder
+            return 0
+        }
+    }
 }

--- a/Sources/PagecallSDK/DeviceManager.swift
+++ b/Sources/PagecallSDK/DeviceManager.swift
@@ -1,0 +1,18 @@
+import AVFoundation
+
+class DeviceManager {
+    static func getAuthorizationStatusAsBool(for type: AVMediaType) -> Bool? {
+        let status = AVCaptureDevice.authorizationStatus(for: type)
+        switch status {
+        case .notDetermined: return nil
+        case .restricted: return false
+        case .denied: return false
+        case .authorized: return true
+        default: return nil
+        }
+    }
+
+    static func requestAccess(for type: AVMediaType, callback: @escaping (Bool) -> Void) {
+        AVCaptureDevice.requestAccess(for: type, completionHandler: callback)
+    }
+}

--- a/Sources/PagecallSDK/MediaController.swift
+++ b/Sources/PagecallSDK/MediaController.swift
@@ -68,6 +68,7 @@ extension AVAudioSession.InterruptionOptions {
 protocol MediaController {
     var emitter: WebViewEmitter { get }
     func start(callback: @escaping (Error?) -> Void)
+    func getAudioVolume() -> Float
     func pauseAudio() -> Bool
     func resumeAudio() -> Bool
     func dispose()

--- a/Sources/PagecallSDK/MiController.swift
+++ b/Sources/PagecallSDK/MiController.swift
@@ -200,4 +200,17 @@ class MiController: MediaController, SendTransportDelegate, ReceiveTransportDele
         sendTransport.close()
         recvTransport.close()
     }
+
+    private var volumeRecorder: VolumeRecorder?
+    func getAudioVolume() -> Float {
+        if let volumeRecorder = volumeRecorder {
+            return volumeRecorder.requestAudioVolume()
+        } else {
+            let volumeRecorder = try! VolumeRecorder()
+            volumeRecorder.highest = -40
+            volumeRecorder.lowest = -70
+            self.volumeRecorder = volumeRecorder
+            return 0
+        }
+    }
 }

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -193,22 +193,10 @@ class NativeBridge {
                     respond(PagecallError(message: "Failed to encode volume"), nil)
                 }
             }
-            // 콜킷 활성화 전에 AVAudioRecorder 사용시 문제 발생
-            if mediaController == nil {
-                respondVolume(0)
-                return
-            }
-
-            if let volumeRecorder = volumeRecorder {
-                let volume = volumeRecorder.requestAudioVolume()
-                respondVolume(volume)
+            if let mediaController = mediaController {
+                respondVolume(mediaController.getAudioVolume())
             } else {
-                do {
-                    self.volumeRecorder = try VolumeRecorder()
-                    respondVolume(0)
-                } catch {
-                    respond(error, nil)
-                }
+                respondVolume(0)
             }
         case .pauseAudio:
             isAudioPaused = true

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -74,7 +74,7 @@ class NativeBridge {
     func messageHandler(message: String) {
         let data = message.data(using: .utf8)!
         guard let jsonArray = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
-            NSLog("Failed to JSONSerialization")
+            print("[NativeBridge] Failed to JSONSerialization")
             return
         }
         guard let action = jsonArray["action"] as? String, let bridgeAction = BridgeAction(rawValue: action), let requestId = jsonArray["requestId"] as? String?, let payload = jsonArray["payload"] as? String? else {

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -29,23 +29,21 @@ class NativeBridge {
     let webview: WKWebView
     let emitter: WebViewEmitter
 
-    // Handled by NativeBridge+AudioSession extension
-    var desiredMode: AVAudioSession.Mode?
-
     var mediaController: MediaController? {
         didSet {
-            stopHandlingInterruption()
+            AudioSessionManager.shared.stopHandlingInterruption()
 
             if let mediaController = mediaController {
                 synchronizePauseState()
                 if let _ = mediaController as? ChimeController {
                     // Chime에서는 videoChat일 경우 소리가 작게 송출된다.
-                    desiredMode = .default
+                    AudioSessionManager.shared.desiredMode = .default
                 } else {
                     // MI에서는 default일 경우 에어팟 연결이 해제된다.
-                    desiredMode = .videoChat
+                    AudioSessionManager.shared.desiredMode = .videoChat
                 }
-                startHandlingInterruption()
+                AudioSessionManager.shared.emitter = emitter
+                AudioSessionManager.shared.startHandlingInterruption()
             }
         }
     }

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -228,8 +228,12 @@ return true;
     }
 
     public func load(roomId: String, mode: PagecallMode) -> WKNavigation? {
+        return load(roomId: roomId, mode: mode, queryItems: [])
+    }
+
+    public func load(roomId: String, mode: PagecallMode, queryItems: [URLQueryItem]) -> WKNavigation? {
         var urlComps = URLComponents(string: mode.baseURLString())!
-        urlComps.queryItems = [URLQueryItem(name: "room_id", value: roomId)]
+        urlComps.queryItems = [URLQueryItem(name: "room_id", value: roomId)] + queryItems
         PagecallLogger.shared.setRoomId(roomId)
         return super.load(URLRequest(url: urlComps.url!))
     }

--- a/Sources/PagecallSDK/VolumeRecorder.swift
+++ b/Sources/PagecallSDK/VolumeRecorder.swift
@@ -2,6 +2,8 @@ import AVFoundation
 
 class VolumeRecorder {
     private let audioRecorder: AVAudioRecorder
+    var lowest: Float = -40 // -70 in MI
+    var highest: Float = -10 // -40 in MI
 
     init() throws {
         let documentPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
@@ -20,12 +22,9 @@ class VolumeRecorder {
     }
 
     private func normalizeSoundLevel(level: Float) -> Float {
-        let lowLevel: Float = -40
-        let highLevel: Float = -10
-
-        var level = max(0.0, level - lowLevel)
-        level = min(level, highLevel - lowLevel)
-        return level / (highLevel - lowLevel) // scaled to 0.0 ~ 1
+        var level = max(0.0, level - lowest)
+        level = min(level, highest - lowest)
+        return level / (highest - lowest) // scaled to 0.0 ~ 1
     }
 
     func requestAudioVolume() -> Float {

--- a/Sources/PagecallSDK/VolumeRecorder.swift
+++ b/Sources/PagecallSDK/VolumeRecorder.swift
@@ -1,0 +1,45 @@
+import AVFoundation
+
+class VolumeRecorder {
+    private let audioRecorder: AVAudioRecorder
+
+    init() throws {
+        let documentPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let audioFilename = documentPath.appendingPathComponent("nothing.m4a")
+        let settings = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 12000,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+        ]
+        audioRecorder = try AVAudioRecorder(url: audioFilename, settings: settings)
+        audioRecorder.isMeteringEnabled = true
+        audioRecorder.record()
+
+        audioRecorder.updateMeters()
+    }
+
+    private func normalizeSoundLevel(level: Float) -> Float {
+        let lowLevel: Float = -40
+        let highLevel: Float = -10
+
+        var level = max(0.0, level - lowLevel)
+        level = min(level, highLevel - lowLevel)
+        return level / (highLevel - lowLevel) // scaled to 0.0 ~ 1
+    }
+
+    func requestAudioVolume() -> Float {
+        audioRecorder.updateMeters()
+        let averagePower = audioRecorder.averagePower(forChannel: 0)
+        let volume = normalizeSoundLevel(level: averagePower)
+        return volume
+    }
+
+    func stop() {
+        audioRecorder.stop()
+    }
+
+    deinit {
+        stop()
+    }
+}


### PR DESCRIPTION
# 변경내용

## 입장페이지에서 볼륨을 볼 수 없거나, 입장 후 크래시가 나는 문제 해결
참고: https://pagecall.slack.com/archives/C04JJM7APD1/p1682324006521209

#18 에서 콜킷을 활성화 한 후 Chime SDK에서만 발생하는 문제입니다.

콜킷 활성화 전에 녹음을 시작하면 Chime SDK에서 송수신이 불가능해집니다. 그리고 30초 후 unknown status code로 세션이 중단됩니다. (이 때 크래시나는 것을 아래 오류해결-2로 해결하였습니다)
이유는 정확히 파악하지 못했으나 마이크에 접근하지 못하게 되는 것으로 보입니다.

콜킷을 활성화 한 후 `AVAudioRecorder`를 사용하면 문제가 해결됩니다. c551ceb693ce2566a45dd96aafeca957d351bb93
한편 WebRTC를 직접 사용할 때 (MIController)와 ChimeSDK를 사용할 때 (ChimeController) 동일한 크기의 소리를 들려줘도 볼륨 범위가 다른 값으로 나오는 것을 발견하여 조정하였습니다. 6d2ed98e2f58dd09db2ee8b0546bf2494d0bfdc2

## 오류해결
1. `podspec` 파일에서는 git 주소 등 소스를 명시할 수 없어서 cocoapod으로 설치해서 사용할 수 없는 문제가 있어 해결했습니다. 48af956b779331379db3207d30e03f5488bee4c1
2. audioSessionStop 문제가 발생했을 때 serialize 가능하지 않은 값을 로그로 찍으려고 시도해서 크래시가 나는 문제를 해결했습니다. 9e14ee61528f71ae371d8fb7b0ac74bb54f97785

## 기타
- 테스트 등의 목적으로 `queryItems`를 넣을 수 있도록 했습니다. 1626fb88ba8f4d610d68086b787e2bcece28c9db
- 로그 일관성 b36d1e681aeadb698c6676b1976c9c5384e5a940
- 역할을 이해하기 쉽도록 클래스를 분리하였습니다.
  - ecf71806c9b65f1c3505031f0b1b6e0e632be506
  - e554864652173fed243f218d533ba8cccf13a887

# 테스트
- UIKit 예제 프로젝트에서 Chime/MI 모두 입장페이지 볼륨 및 송수신이 잘 동작하는 것을 확인했습니다.
- flutter_inappwebview_pagecall 에 연결해 입장페이지 볼륨 및 송수신이 잘 동작하는 것을 확인했습니다.