### PR TITLE
fix: change position of startVolumeScheduler

### DIFF
--- a/Sources/PagecallSDK/MiController.swift
+++ b/Sources/PagecallSDK/MiController.swift
@@ -114,7 +114,6 @@ class MiController: MediaController, SendTransportDelegate, ReceiveTransportDele
 
     init(emitter: WebViewEmitter, initialPayload: MiInitialPayload) throws {
         self.emitter = emitter
-        self.startVolumeScheduler()
         try device.load(with: initialPayload.rtpCapabilities)
         sendTransport = try device.createSendTransport(
             id: initialPayload.send.id,
@@ -165,6 +164,8 @@ class MiController: MediaController, SendTransportDelegate, ReceiveTransportDele
     }
 
     func start(callback: @escaping (Error?) -> Void) {
+        self.startVolumeScheduler()
+        
         let audioSource = factory.audioSource(with: RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil))
         let audioTrack = factory.audioTrack(with: audioSource, trackId: "audio0")
 

--- a/Sources/PagecallSDK/VolumeRecorder.swift
+++ b/Sources/PagecallSDK/VolumeRecorder.swift
@@ -2,8 +2,8 @@ import AVFoundation
 
 class VolumeRecorder {
     private let audioRecorder: AVAudioRecorder
-    var lowest: Float = -40 // -70 in MI
-    var highest: Float = -10 // -40 in MI
+    var lowest: Float = -40 // -50 in MI
+    var highest: Float = -10 // -10 in MI
 
     init() throws {
         let documentPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]


### PR DESCRIPTION
self.startVolumeScheduler 가 init 내부에 있을 때에는 'self' used in method call 'startVolumeScheduler' before all stored properties are initialized' 오류가 발생했습니다.
위 오류를 해결하는 목적과 함께 start 함수 내에 위치하는 것이 자연스럽다고 판단하여 위치를 옮겼습니다.
목적대로 동작하는 것 테스트 완료했습니다.