### PR TITLE
일부 기기 입장페이지에서 오디오볼륨이 동작하지 않는 문제를 해결

### DIFF
--- a/Sources/PagecallSDK/AudioSessionManager.swift
+++ b/Sources/PagecallSDK/AudioSessionManager.swift
@@ -46,10 +46,12 @@ class AudioSessionManager {
                     "uid": output.uid]
         }
 
-        guard let payload = try? JSONSerialization.data(withJSONObject: ["reason": reason.description,
-                                                                         "outputs": currentRouteOutputs,
-                                                                         "category": audioSession.category.rawValue] as [String: Any],
-                                                        options: .withoutEscapingSlashes) else { return }
+        let routeChangeDetail: [String: Any] = [
+            "reason": reason.description,
+            "outputs": currentRouteOutputs,
+            "category": audioSession.category.rawValue
+        ]
+        guard let payload = try? JSONSerialization.data(withJSONObject: routeChangeDetail, options: .withoutEscapingSlashes) else { return }
 
         self.emitter?.emit(eventName: .audioSessionRouteChanged, data: payload)
 
@@ -95,10 +97,12 @@ class AudioSessionManager {
             payloadOptions = "None"
         }
 
-        guard let payload = try? JSONSerialization.data(withJSONObject: ["type": payloadType,
-                                                                         "reason": payloadReason,
-                                                                         "options": payloadOptions] as [String: Any],
-                                                        options: .withoutEscapingSlashes) else { return }
+        let interruptionDetail: [String: Any] = [
+            "type": payloadType,
+            "reason": payloadReason,
+            "options": payloadOptions
+        ]
+        guard let payload = try? JSONSerialization.data(withJSONObject: interruptionDetail, options: .withoutEscapingSlashes) else { return }
         self.emitter?.emit(eventName: .audioSessionInterrupted, data: payload)
     }
 

--- a/Sources/PagecallSDK/ChimeController.swift
+++ b/Sources/PagecallSDK/ChimeController.swift
@@ -125,14 +125,30 @@ class ChimeController: MediaController {
     }
 
     private var volumeRecorder: VolumeRecorder?
-    func getAudioVolume() -> Float {
-        if let volumeRecorder = volumeRecorder {
-            return volumeRecorder.requestAudioVolume()
-        } else {
-            let volumeRecorder = try! VolumeRecorder()
+    private func initializeVolumeRecorder() {
+        self.volumeRecorder?.stop()
+        do {
+            let volumeRecorder = try VolumeRecorder()
             volumeRecorder.highest = -10
             volumeRecorder.lowest = -40
             self.volumeRecorder = volumeRecorder
+        } catch {
+            self.emitter.error(error)
+        }
+    }
+
+    func getAudioVolume() -> Float {
+        if let volumeRecorder = volumeRecorder {
+            do {
+                let volume = try volumeRecorder.requestAudioVolume()
+                return volume
+            } catch {
+                self.emitter.error(error)
+                initializeVolumeRecorder()
+                return 0
+            }
+        } else {
+            initializeVolumeRecorder()
             return 0
         }
     }

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -84,7 +84,7 @@ class NativeBridge {
                 if let requestId = requestId {
                     self.emitter.response(requestId: requestId, errorMessage: error.localizedDescription)
                 } else {
-                    self.emitter.error(name: "RequestFailed", message: error.localizedDescription)
+                    self.emitter.error(error)
                 }
             } else {
                 if let requestId = requestId {
@@ -112,7 +112,7 @@ class NativeBridge {
             let respondError: (Error) -> Void = { error in
                 CallManager.shared.endCall { endCallError in
                     if let endCallError = endCallError {
-                        self.emitter.error(name: "EndCallError", message: endCallError.localizedDescription)
+                        self.emitter.error(endCallError)
                     }
                     respond(error, nil)
                 }
@@ -226,7 +226,7 @@ class NativeBridge {
         case .dispose:
             self.disconnect { error in
                 guard let error = error else { return }
-                self.emitter.error(name: "DisconnectFailure", message: error.localizedDescription)
+                self.emitter.error(error)
             }
             respond(nil, nil)
         case .setAudioDevice:

--- a/Sources/PagecallSDK/VolumeRecorder.swift
+++ b/Sources/PagecallSDK/VolumeRecorder.swift
@@ -27,9 +27,15 @@ class VolumeRecorder {
         return level / (highest - lowest) // scaled to 0.0 ~ 1
     }
 
-    func requestAudioVolume() -> Float {
+    func requestAudioVolume() throws -> Float {
         audioRecorder.updateMeters()
         let averagePower = audioRecorder.averagePower(forChannel: 0)
+        if averagePower <= -120 {
+            // 일부 기기에서 마이크 사용중 표시(주황색 동그라미)가 꺼지면서 볼륨이 계속 -120 으로 찍히는 경우가 있습니다.
+            // 이 때는 AVAudioRecorder를 재생성해주면 해결됩니다.
+            // 아무리 조용해도 -80 정도는 나오는 것이 정상입니다.
+            throw PagecallError(message: "AVAudioRecorder seems to be broken")
+        }
         let volume = normalizeSoundLevel(level: averagePower)
         return volume
     }

--- a/Sources/PagecallSDK/WebViewEmitter.swift
+++ b/Sources/PagecallSDK/WebViewEmitter.swift
@@ -98,6 +98,14 @@ class WebViewEmitter {
         }
     }
 
+    func error(_ error: Error) {
+        if let error = error as? PagecallError {
+            self.error(name: "HandlediOSSDKError", message: error.message)
+        } else {
+            self.error(name: "UnexpectediOSSDKError", message: error.localizedDescription)
+        }
+    }
+
     func error(name: String, message: String?) {
         guard let data = try? JSONEncoder().encode(ErrorEvent(name: name, message: message?.javaScriptString)) else { return }
         self.emit(eventName: .error, data: data)


### PR DESCRIPTION
특정 아이패드는 입장페이지에서 오디오볼륨이 동작하지 않는 문제가 발견되었습니다.
Interruption이나 RouteChange가 있는 경우도 있지만 그렇지 않은 경우도 있었습니다. 이 문제가 발생한 것을 감지할 수 있는 것은 `averagePower`가 -120.0 으로 나온다는 것이었습니다. `AVAudioRecorder`를 재생성하면 정상화되는 것을 확인해 그렇게 재시도하도록 변경했습니다.