### PR TITLE
Force userAgent to contain pagecall hint

### DIFF
--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -92,7 +92,6 @@ open class PagecallWebView: WKWebView {
         configuration.mediaTypesRequiringUserActionForPlayback = []
         configuration.allowsInlineMediaPlayback = true
         configuration.suppressesIncrementalRendering = false
-        configuration.applicationNameForUserAgent = "PagecallIos"
         configuration.allowsAirPlayForMediaPlayback = true
         configuration.defaultWebpagePreferences.preferredContentMode = .mobile
 
@@ -114,12 +113,24 @@ open class PagecallWebView: WKWebView {
         uiDelegate = self
         navigationDelegate = self
         allowsBackForwardNavigationGestures = false
-        customUserAgent = [safariUserAgent, "PagecalliOSSDK/\(PagecallWebView.version)"].compactMap { $0 }.joined(separator: " ")
+        customUserAgent = nil // Trigger setting default value
         scrollView.contentInsetAdjustmentBehavior = .never
 
         let interaction = UIPencilInteraction()
         interaction.delegate = self
         addInteraction(interaction)
+    }
+
+    public override var customUserAgent: String? {
+        didSet {
+            let pagecallUserAgent = "PagecalliOSSDK/\(PagecallWebView.version)"
+            if let customUserAgent = customUserAgent, customUserAgent.count > 0 {
+                if customUserAgent.contains(pagecallUserAgent) { return }
+                self.customUserAgent = [customUserAgent, pagecallUserAgent].joined(separator: " ")
+            } else {
+                customUserAgent = [safariUserAgent, pagecallUserAgent].joined(separator: " ")
+            }
+        }
     }
 
     private var callbacks = [String: (Any?) -> Void]()


### PR DESCRIPTION
정확한 디버깅을 위해서는 어떤 환경에서 페이지콜이 구동되고 있는지 파악할 필요가 있습니다.
`customUserAgent`를 셋해주면 기본값이 오버라이드되기 때문에 어떤 값을 넣더라도 남아있을 수 있도록 강제합니다.