### PR TITLE
feat: replay mode 에서도 이벤트 메시지를 받습니다.

### DIFF
--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -376,7 +376,7 @@ extension PagecallWebView: WKNavigationDelegate {
         decisionHandler(.allow)
     }
 
-    private func addLeakAvoider() {
+    private func listenJavascriptMessages() {
         configuration.userContentController.add(LeakAvoider(delegate: self), name: self.controllerName)
         cleanups.append({
             self.configuration.userContentController.removeScriptMessageHandler(forName: self.controllerName)
@@ -384,7 +384,7 @@ extension PagecallWebView: WKNavigationDelegate {
     }
 
     private func initializePageContext() {
-        addLeakAvoider()
+        listenJavascriptMessages()
 
         // Enable call
         CallManager.shared.startCall { error in
@@ -425,7 +425,7 @@ extension PagecallWebView: WKNavigationDelegate {
             initializePageContext()
         } else if let isPagecallReplay = webView.url?.absoluteString.contains(PagecallMode.replay.baseURLString()), isPagecallReplay {
             cleanupPagecallContext()
-            addLeakAvoider()
+            listenJavascriptMessages()
         }
     }
 

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -419,6 +419,13 @@ extension PagecallWebView: WKNavigationDelegate {
         if let isPagecallMeeting = webView.url?.absoluteString.contains(PagecallMode.meet.baseURLString()), isPagecallMeeting {
             cleanupPagecallContext()
             initializePageContext()
+        } else if let isPagecallReplay = webView.url?.absoluteString.contains(PagecallMode.replay.baseURLString()), isPagecallReplay {
+            cleanupPagecallContext()
+            
+            configuration.userContentController.add(LeakAvoider(delegate: self), name: self.controllerName)
+            cleanups.append({
+                self.configuration.userContentController.removeScriptMessageHandler(forName: self.controllerName)
+            })
         }
     }
 

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -294,7 +294,7 @@ extension PagecallWebView: WKScriptMessageHandler {
             case "PagecallEvent":
                 guard let action = body["action"] as? String else { return }
                 if action == "loaded" {
-                    delegate?.pagecallDidLoad(self);
+                    delegate?.pagecallDidLoad(self)
                 } else if action == "terminated" {
                     if let payload = body["payload"] as? [String: String], let reason = payload["reason"] {
                         if reason == "internal" {
@@ -376,11 +376,15 @@ extension PagecallWebView: WKNavigationDelegate {
         decisionHandler(.allow)
     }
 
-    private func initializePageContext() {
+    private func addLeakAvoider() {
         configuration.userContentController.add(LeakAvoider(delegate: self), name: self.controllerName)
         cleanups.append({
             self.configuration.userContentController.removeScriptMessageHandler(forName: self.controllerName)
         })
+    }
+
+    private func initializePageContext() {
+        addLeakAvoider()
 
         // Enable call
         CallManager.shared.startCall { error in
@@ -421,11 +425,7 @@ extension PagecallWebView: WKNavigationDelegate {
             initializePageContext()
         } else if let isPagecallReplay = webView.url?.absoluteString.contains(PagecallMode.replay.baseURLString()), isPagecallReplay {
             cleanupPagecallContext()
-            
-            configuration.userContentController.add(LeakAvoider(delegate: self), name: self.controllerName)
-            cleanups.append({
-                self.configuration.userContentController.removeScriptMessageHandler(forName: self.controllerName)
-            })
+            addLeakAvoider()
         }
     }
 


### PR DESCRIPTION
SDK 코드를 변경하여 replay mode에도 이벤트 메시지를 받습니다.

이전에는 replay mode 에는 pagecallDidLoad, pagecallDidTerminate, pagecallDidReceive 등의 함수들을 호출하지 못했습니다. 