### PR TITLE
feat: Added Apple Pencil connection monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Make sure you set `NSMicrophoneUsageDescription`
   - Video call is currently not supported. If you need video conferencing integrated in your service, please contact support@pagecall.com
 - Also, Those `UIBackgroundModes` should be enabled: `audio`, `fetch`, `voip`.
+- **Optional but Recommended**: Add `NSBluetoothAlwaysUsageDescription` to your Info.plist. This allows Pagecall to monitor the connection status of user's Apple Pencil, making it easier to diagnose issues.
 
 ## Usages
 

--- a/Sources/PagecallSDK/ApplePencilMonitor.swift
+++ b/Sources/PagecallSDK/ApplePencilMonitor.swift
@@ -1,0 +1,66 @@
+import CoreBluetooth
+
+// Notification name 정의
+extension Notification.Name {
+    static let applePencilConnectionChanged = Notification.Name("applePencilConnectionChanged")
+}
+
+class ApplePencilMonitor: NSObject, CBCentralManagerDelegate {
+
+    private var centralManager: CBCentralManager!
+    private var timer: Timer!
+    private var applePencilConnected: Bool = false
+    
+    override init() {
+        if Bundle.main.infoDictionary?["NSBluetoothAlwaysUsageDescription"] != nil {
+            super.init()
+            self.centralManager = CBCentralManager(delegate: self, queue: nil)
+        } else {
+            print("[ApplePencilMonitor] NSBluetoothAlwaysUsageDescription key is not found in Info.plist")
+            super.init()
+        }
+    }
+
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        if central.state == .poweredOn {
+            self.startPolling()
+        } else {
+            self.stopPolling()
+        }
+    }
+
+    private func startPolling() {
+        self.timer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { timer in
+            let services = [CBUUID(string: "180A")] // 180A is the service UUID for Device Information
+            let devices = self.centralManager.retrieveConnectedPeripherals(withServices: services)
+            for device in devices {
+                if device.name == "Apple Pencil" {
+                    // Pencil is connected
+                    if !self.applePencilConnected {
+                        self.applePencilConnected = true
+                        NotificationCenter.default.post(name: .applePencilConnectionChanged, object: nil, userInfo: ["connected": true])
+                    }
+                    return
+                }
+            }
+            // If no pencil is found
+            if self.applePencilConnected {
+                self.applePencilConnected = false
+                NotificationCenter.default.post(name: .applePencilConnectionChanged, object: nil, userInfo: ["connected": false])
+            }
+        }
+    }
+
+    private func stopPolling() {
+        self.timer?.invalidate()
+        self.timer = nil
+    }
+    
+    func dispose() {
+        self.stopPolling()
+        self.centralManager = nil
+    }
+    deinit {
+        self.dispose()
+    }
+}

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -23,6 +23,8 @@ class NativeBridge: Equatable {
         return lhs.id == rhs.id
     }
 
+    private var applePencilMonitor: ApplePencilMonitor?
+    
     private let webview: PagecallWebView
     private let emitter: WebViewEmitter
 
@@ -69,6 +71,17 @@ class NativeBridge: Equatable {
         id = NativeBridge.count
         self.webview = webview
         self.emitter = .init(webView: self.webview)
+        self.applePencilMonitor = ApplePencilMonitor()
+        NotificationCenter.default.addObserver(self, selector: #selector(self.applePencilConnectionChanged(notification:)), name: .applePencilConnectionChanged, object: nil)
+    }
+    @objc func applePencilConnectionChanged(notification: Notification) {
+        if let userInfo = notification.userInfo, let isConnected = userInfo["connected"] as? Bool {
+            if isConnected {
+                emitter.log(name: "ApplePencilConnection", message: "Connected")
+            } else {
+                emitter.log(name: "ApplePencilConnection", message: "Disconnected")
+            }
+        }
     }
 
     func messageHandler(message: String) {
@@ -259,6 +272,9 @@ class NativeBridge: Equatable {
 
     deinit {
         disconnect()
+        // Do not dispose applePencilMonitor in the "disconnect"
+        applePencilMonitor?.dispose()
+        applePencilMonitor = nil
     }
 }
 

--- a/examples/swiftui/SwiftUI-Example-Info.plist
+++ b/examples/swiftui/SwiftUI-Example-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>We use Bluetooth to monitor Apple Pencil.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>


### PR DESCRIPTION
# Changes
- 3초마다 애플펜슬 연결을 확인하여 연결 상태가 변경될 때 emitter로 전달합니다.

# Test
- info.plist 에 `NSBluetoothAlwaysUsageDescription`가 없더라도 앱이 크래시 나지 않는 것을 확인했습니다.
- info.plist 에 `NSBluetoothAlwaysUsageDescription`가 기재되어 있으면 디버거에서 로그가 잘 보이는 것을 확인했습니다.
<img width="320" alt="Pasted Graphic 76" src="https://github.com/pagecall/pagecall-ios-sdk/assets/19991994/d5c347bb-ccca-46ee-b1ed-3a82851a5e18">
