### PR TITLE
Handle crash related with authChallenge

### DIFF
--- a/Sources/PagecallSDK/PagecallLogger.swift
+++ b/Sources/PagecallSDK/PagecallLogger.swift
@@ -29,6 +29,14 @@ public class PagecallLogger {
         #endif
     }
 
+    func addBreadcrumb(message: String) {
+        #if canImport(Sentry)
+        let crumb = Breadcrumb()
+        crumb.message = message
+        SentrySDK.addBreadcrumb(crumb)
+        #endif
+    }
+
     func capture(message: String) {
         #if canImport(Sentry)
         SentrySDK.capture(message: message)

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -133,6 +133,34 @@ open class PagecallWebView: WKWebView {
         }
     }
 
+    @available(*, deprecated, message: "Please use delegate, as uiDelegate is handled internally")
+    public override var uiDelegate: WKUIDelegate? {
+        didSet {
+            if let uiDelegate = uiDelegate {
+                if !uiDelegate.isEqual(self) {
+                    fatalError("uiDelegate cannot be overridden")
+                }
+            } else {
+                print("[PagecallWebView] uiDelegate cannot be unset")
+                uiDelegate = self
+            }
+        }
+    }
+
+    @available(*, deprecated, message: "Please use delegate, as navigationDelegate is handled internally")
+    public override var navigationDelegate: WKNavigationDelegate? {
+        didSet {
+            if let navigationDelegate = navigationDelegate {
+                if !navigationDelegate.isEqual(self) {
+                    fatalError("navigationDelegate cannot be overridden")
+                }
+            } else {
+                print("[PagecallWebView] navigationDelegate cannot be unset")
+                navigationDelegate = self
+            }
+        }
+    }
+
     private var callbacks = [String: (Any?) -> Void]()
     public func getReturnValue(script: String, completion: @escaping (Any?) -> Void) {
         let id = UUID().uuidString

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -393,7 +393,7 @@ extension PagecallWebView: WKNavigationDelegate {
                 PagecallLogger.shared.capture(error: error)
                 self.delegate?.pagecallDidEncounter(self, error: error)
             } else {
-                PagecallLogger.shared.capture(message: "Call started")
+                PagecallLogger.shared.addBreadcrumb(message: "Call started")
             }
         }
         cleanups.append({
@@ -403,7 +403,7 @@ extension PagecallWebView: WKNavigationDelegate {
                     PagecallLogger.shared.capture(error: error)
                     self.delegate?.pagecallDidEncounter(self, error: error)
                 } else {
-                    PagecallLogger.shared.capture(message: "Call ended")
+                    PagecallLogger.shared.addBreadcrumb(message: "Call ended")
                 }
             }
         })

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -345,10 +345,17 @@ extension PagecallWebView: WKNavigationDelegate {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
-        let cred = URLCredential(trust: challenge.protectionSpace.serverTrust!)
-        DispatchQueue.global(qos: .userInitiated).async {
-             completionHandler(.useCredential, cred)
-         }
+        if let serverTrust = challenge.protectionSpace.serverTrust {
+            let cred = URLCredential(trust: serverTrust)
+            DispatchQueue.global(qos: .userInitiated).async {
+                completionHandler(.useCredential, cred)
+            }
+        } else {
+            PagecallLogger.shared.capture(message: "Missing serverTrust")
+            DispatchQueue.global(qos: .userInitiated).async {
+                completionHandler(.performDefaultHandling, nil)
+            }
+        }
     }
 
     open func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {

--- a/Sources/PagecallSDK/VolumeRecorder.swift
+++ b/Sources/PagecallSDK/VolumeRecorder.swift
@@ -3,7 +3,7 @@ import AVFoundation
 class VolumeRecorder {
     private let audioRecorder: AVAudioRecorder
     let emitter: WebViewEmitter
-    
+
     var lowest: Float = -40 // -50 in MI
     var highest: Float = -10 // -10 in MI
 
@@ -31,7 +31,7 @@ class VolumeRecorder {
     }
 
     var unusualAveragePowerCount = 0
-    
+
     func requestAudioVolume() throws -> Float {
         audioRecorder.updateMeters()
         let averagePower = audioRecorder.averagePower(forChannel: 0)

--- a/examples/swiftui/SwiftUI Example/Helpers/ProgressBar.swift
+++ b/examples/swiftui/SwiftUI Example/Helpers/ProgressBar.swift
@@ -36,7 +36,7 @@ struct ProgressBar: View {
                         .fill(barColor)
                         .frame(height: 2)
                 }
-                .offset(x: 30) //necessary to match alignment because of the image size
+                .offset(x: 30) // necessary to match alignment because of the image size
                 .frame(width: xOffset)
                 .animation(.linear, value: progress)
                 .alignmentGuide(VerticalAlignment.center) { $0[.bottom] }

--- a/examples/uikit/UIKit Example.xcodeproj/project.pbxproj
+++ b/examples/uikit/UIKit Example.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QTGVHKHLYT;
+				DEVELOPMENT_TEAM = 9H2SNY3HBF;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "UIKit Example/Info.plist";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Pagecall requires microphone access for voicechat";
@@ -414,7 +414,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QTGVHKHLYT;
+				DEVELOPMENT_TEAM = 9H2SNY3HBF;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "UIKit Example/Info.plist";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Pagecall requires microphone access for voicechat";

--- a/examples/uikit/UIKit Example/Helpers/SendMessage.swift
+++ b/examples/uikit/UIKit Example/Helpers/SendMessage.swift
@@ -15,7 +15,7 @@ final class SendMessage: UIView {
     private let textFieldOverlay = UIView()
     let textField = UITextField()
     private let sendMessage: (String, ((Error?) -> Void)?) -> Void
-    
+
     init(sendMessage: @escaping (String, ((Error?) -> Void)?) -> Void) {
         self.sendMessage = sendMessage
         super.init(frame: .zero)


### PR DESCRIPTION
`Completion handler passed to -[NSObject webView:didReceiveAuthenticationChallenge:completionHandler:] was not called` 메시지와 함께 크래시가 나는 경우가 발견되었습니다.
가능한 상황들에 대응하고 로깅합니다.