### PR TITLE
feat: add pagecallDidCommit, pagecallDidFailLoad listener

### DIFF
--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -8,7 +8,9 @@ public enum TerminationReason {
 public protocol PagecallDelegate: AnyObject {
     func pagecallDidTerminate(_ view: PagecallWebView, reason: TerminationReason)
     func pagecallDidEncounter(_ view: PagecallWebView, error: Error)
+    func pagecallDidCommit(_ view: PagecallWebView)
     func pagecallDidLoad(_ view: PagecallWebView)
+    func pagecallDidFailLoad(_ view: PagecallWebView, error: Error)
     func pagecallDidReceive(_ view: PagecallWebView, message: String)
     func pagecall(_ view: PagecallWebView, requestDownloadFor url: URL)
 }
@@ -16,7 +18,9 @@ public protocol PagecallDelegate: AnyObject {
 // Optional delegates
 public extension PagecallDelegate {
     func pagecallDidEncounter(_ view: PagecallWebView, error: Error) {}
+    func pagecallDidCommit(_ view: PagecallWebView) {}
     func pagecallDidLoad(_ view: PagecallWebView) {}
+    func pagecallDidFailLoad(_ view: PagecallWebView, error: Error) {}
     func pagecallDidReceive(_ view: PagecallWebView, message: String) {}
     func pagecall(_ view: PagecallWebView, requestDownloadFor url: URL) {}
 }
@@ -368,6 +372,9 @@ extension PagecallWebView: WKUIDelegate {
 }
 
 extension PagecallWebView: WKNavigationDelegate {
+    open func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        self.delegate?.pagecallDidCommit(self)
+    }
     open func webView(
         _ webView: WKWebView,
         didReceive challenge: URLAuthenticationChallenge,
@@ -470,7 +477,7 @@ extension PagecallWebView: WKNavigationDelegate {
 
     open func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         PagecallLogger.shared.capture(error: error)
-        self.delegate?.pagecallDidEncounter(self, error: error)
+        self.delegate?.pagecallDidFailLoad(self, error: error)
     }
 
     open func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {

--- a/examples/swiftui/SwiftUI Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/swiftui/SwiftUI Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "2479b6f7ff69b66bcdea82184d097667e63828ed",
-          "version": "8.5.0"
+          "revision": "259d8bc75aa4028416535d35840ff19fc7661292",
+          "version": "8.9.3"
         }
       }
     ]

--- a/examples/swiftui/SwiftUI Example/ViewModel/PagecallWebViewModel.swift
+++ b/examples/swiftui/SwiftUI Example/ViewModel/PagecallWebViewModel.swift
@@ -36,6 +36,10 @@ class PagecallWebViewModel: PagecallDelegate, ObservableObject {
         pagecallWebView.sendMessage(message: message, completionHandler: nil)
     }
 
+    public func pagecallDidCommit(_ view: PagecallWebView) {
+        print("pagecallWebView did commit")
+    }
+    
     public func pagecallDidLoad(_ view: PagecallWebView) {
         state = .loaded
     }

--- a/examples/uikit/Podfile.lock
+++ b/examples/uikit/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Pagecall (0.0.15)
-  - Pagecall/Log (0.0.15):
+  - Pagecall (0.0.17)
+  - Pagecall/Log (0.0.17):
     - Sentry (~> 8.0.0)
   - Sentry (8.0.0):
     - Sentry/Core (= 8.0.0)
@@ -23,7 +23,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Pagecall: 3488f4fdbbd31e4730bf8ad0a829379a0b5c496f
+  Pagecall: 619269ba3d8a78a9339cc079d1f5b5cab30252ef
   Sentry: 2158a4621096dcd0a3a4f7c80b84b04dde261035
   SentryPrivate: 1e3acf96ee818a8d0d95b8e922d39ab6be338ea0
 

--- a/examples/uikit/UIKit Example/PagecallViewController.swift
+++ b/examples/uikit/UIKit Example/PagecallViewController.swift
@@ -177,18 +177,16 @@ extension PagecallViewController: PagecallDelegate {
 
     }
 
-    func pagecallDidEncounter(_ view: PagecallWebView, error: Error) {
-        DispatchQueue.main.async {
-            self.loading.setProgress(progress: 0.25)
-        }
-    }
-
     func pagecallDidReceive(_ view: PagecallWebView, message: String) {
         messageBox.setText(message: message)
         messageBox.isHidden = false
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 3) {
             self.messageBox.isHidden = true
         }
+    }
+    
+    func pagecallDidCommit(_ view: PagecallWebView) {
+        print("pagecallWebView did commit")
     }
 
     func pagecallDidLoad(_ view: PagecallWebView) {
@@ -197,7 +195,12 @@ extension PagecallViewController: PagecallDelegate {
             self.loading.isHidden = true
         }
     }
-
+    
+    func pagecallDidFailLoad(_ view: PagecallWebView, error: Error) {
+        DispatchQueue.main.async {
+            self.loading.setProgress(progress: 0.25)
+        }
+    }
 }
 
 extension PagecallViewController {


### PR DESCRIPTION
# Changes
- [didCommit](https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455635-webview) 을 받아서 PagecallDelegate로 넘겨줍니다.
- [didFail](https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455623-webview) 을 didEncounter로 퉁치지 않고 pagecallDidFailLoad로 더 좁혀서 알려줍니다.

# Tests
- UiKit example로 실기기 테스트 완료 했습니다.
- 참고로 SwiftUI example에 문제가 있습니다. (화면이 까맣게 나옴)
  - 언제부터였는지는 모름