### PR TITLE
chore: not call pagecallDidEncounter for CallKit error

### DIFF
--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -426,7 +426,6 @@ extension PagecallWebView: WKNavigationDelegate {
             if let error = error {
                 print("[PagecallWebView] Failed to start call")
                 PagecallLogger.shared.capture(error: error)
-                self.delegate?.pagecallDidEncounter(self, error: error)
             } else {
                 PagecallLogger.shared.addBreadcrumb(message: "Call started")
             }
@@ -436,7 +435,6 @@ extension PagecallWebView: WKNavigationDelegate {
                 if let error = error {
                     print("[PagecallWebView] Failed to end call")
                     PagecallLogger.shared.capture(error: error)
-                    self.delegate?.pagecallDidEncounter(self, error: error)
                 } else {
                     PagecallLogger.shared.addBreadcrumb(message: "Call ended")
                 }

--- a/examples/swiftui/SwiftUI Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/swiftui/SwiftUI Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "2479b6f7ff69b66bcdea82184d097667e63828ed",
-          "version": "8.5.0"
+          "revision": "259d8bc75aa4028416535d35840ff19fc7661292",
+          "version": "8.9.3"
         }
       }
     ]

--- a/examples/uikit/Podfile.lock
+++ b/examples/uikit/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Pagecall (0.0.15)
-  - Pagecall/Log (0.0.15):
+  - Pagecall (0.0.17)
+  - Pagecall/Log (0.0.17):
     - Sentry (~> 8.0.0)
   - Sentry (8.0.0):
     - Sentry/Core (= 8.0.0)
@@ -23,7 +23,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Pagecall: 3488f4fdbbd31e4730bf8ad0a829379a0b5c496f
+  Pagecall: 619269ba3d8a78a9339cc079d1f5b5cab30252ef
   Sentry: 2158a4621096dcd0a3a4f7c80b84b04dde261035
   SentryPrivate: 1e3acf96ee818a8d0d95b8e922d39ab6be338ea0
 


### PR DESCRIPTION
# Changes
- pagecallDidEncounter 가 받는 에러의 심각도 조건을 높입니다.
- CallKit 관련 에러는 심각도가 충분하지 않다고 판단하여 제외했습니다. 

# Tests
- UIKit example에서 테스트