### PR TITLE
Handle uncaught errors, Add breadcrumbs

### DIFF
--- a/examples/uikit/UIKit Example/HomeViewController.swift
+++ b/examples/uikit/UIKit Example/HomeViewController.swift
@@ -249,12 +249,22 @@ extension HomeViewController {
         alertViewBottomConstraint?.constant = -HomeViewConstants.Layout.PaddingUnderAlert
     }
 
+    private func openPagecall(mode: PagecallMode) {
+        let queryItems = parseQueryItems()
+        var vc: PagecallViewController?
+        vc = PagecallViewController(roomId: roomSubview.text, accessToken: tokenSubview.text, mode: mode, queryItems: queryItems) { error in
+            let alert = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+            alert.addAction(.init(title: "OK", style: .default, handler: { _ in
+                self.navigationController?.popViewController(animated: true)
+            }))
+            self.present(alert, animated: true, completion: nil)
+        }
+        self.navigationController?.pushViewController(vc!, animated: true)
+    }
+
     @objc func onReplayButtonTap() {
         if roomSubview.text != "" && tokenSubview.text != "" {
-            let queryItems = parseQueryItems()
-            let vc = PagecallViewController(roomId: roomSubview.text, accessToken: tokenSubview.text, mode: .replay, queryItems: queryItems)
-
-            self.navigationController?.pushViewController(vc, animated: true)
+            openPagecall(mode: .replay)
         } else {
             alert.isHidden = false
         }
@@ -262,10 +272,7 @@ extension HomeViewController {
 
     @objc func onEnterButtonTap() {
         if roomSubview.text != "" && tokenSubview.text != "" {
-            let queryItems = parseQueryItems()
-            let vc = PagecallViewController(roomId: roomSubview.text, accessToken: tokenSubview.text, mode: .meet, queryItems: queryItems)
-
-            self.navigationController?.pushViewController(vc, animated: true)
+            openPagecall(mode: .meet)
         } else {
             alert.isHidden = false
         }


### PR DESCRIPTION
- Add breadcrumbs for debug
- Navigation failure cases from offline state or unreachable host are handled in `webViewDidFailProvisionalNavigation`, not `webViewDidFailNavigation`. Forward them to `pagecallDidEncounter` for customers to handle.
- Add alerts in sample app
  <img width="1181" alt="스크린샷 2023-11-15 오후 4 25 26" src="https://github.com/pagecall/pagecall-ios-sdk/assets/19246445/89e79e2c-e9eb-4367-9c51-43b066c022c1">
  <img width="1178" alt="스크린샷 2023-11-15 오후 4 38 39" src="https://github.com/pagecall/pagecall-ios-sdk/assets/19246445/6f628757-767a-4391-a2fb-b8f94ef4d054">
