### PR TITLE
Ensure unload

### DIFF
--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -311,7 +311,11 @@ extension PagecallWebView {
                 print("[PagecallWebView] a non-pagecall url is loaded")
             }
         }
-        return super.load(request)
+        let result = super.load(request)
+        cleanups.append({
+            super.load(URLRequest(url: URL(string:"about:blank")!))
+        })
+        return result
     }
 
     @available(*, deprecated, message: "Please use load(roomId) instead")

--- a/examples/uikit/Podfile.lock
+++ b/examples/uikit/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Pagecall (0.0.21)
-  - Pagecall/Log (0.0.21):
+  - Pagecall (0.0.22)
+  - Pagecall/Log (0.0.22):
     - Sentry (~> 8.0.0)
   - Sentry (8.0.0):
     - Sentry/Core (= 8.0.0)
@@ -23,7 +23,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Pagecall: 0b155cc32e7f3b4faabc14ecd63366dcd0d1a9f7
+  Pagecall: 52e7f6c5cca591687888357f44919ed5b268b925
   Sentry: 2158a4621096dcd0a3a4f7c80b84b04dde261035
   SentryPrivate: 1e3acf96ee818a8d0d95b8e922d39ab6be338ea0
 

--- a/examples/uikit/UIKit Example/Helpers/LabelAndTextFieldView.swift
+++ b/examples/uikit/UIKit Example/Helpers/LabelAndTextFieldView.swift
@@ -18,6 +18,9 @@ final class LabelAndTextFieldView: UIView {
         get {
             return textField.text!
         }
+        set {
+            textField.text = newValue
+        }
     }
 
     init(labelText: String) {

--- a/examples/uikit/UIKit Example/HomeViewController.swift
+++ b/examples/uikit/UIKit Example/HomeViewController.swift
@@ -67,6 +67,10 @@ class HomeViewController: UIViewController {
 
         addKeyboardNotifications()
         addTapGestures()
+
+        // You can replace it with a desired value when testing.
+        roomSubview.text = ""
+        tokenSubview.text = ""
    }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
A websocket inside the web view was being not closed, which leads to a late webhook delivery. 
This introduces an additional step of unload to make sure the page context, including websockets, is safely destroyed.