### PR TITLE
Manual unload, Call on the first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 ## Usages
 
+Be sure to call the `cleanup` method when a `PagecallWebView` instance is no longer in use.
+
 ### [UIKit Example](/examples/uikit)
 It is not supported to instantiate from a storyboard. You need to programatically create a PagecallWebView or PagecallWebViewController.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,20 @@
 
 ## Usages
 
-Be sure to call the `cleanup` method when a `PagecallWebView` instance is no longer in use.
+- Be sure to call the `cleanup` method when a `PagecallWebView` instance is no longer in use.
+- Please add the following code. If not added, CallKit may not be activated on the first run, resulting in decreased voice call stability.
+
+```swift
+...
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    ...
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        PagecallWebView.configure()
+        ...
+        return true
+    }
+}
+```
 
 ### [UIKit Example](/examples/uikit)
 It is not supported to instantiate from a storyboard. You need to programatically create a PagecallWebView or PagecallWebViewController.

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -29,14 +29,14 @@ func parseMediaStats(jsonString: String) -> Result<Stat, Error> {
           let array = parsedData as? [[String: Any]] else {
         return .failure(PagecallError.other(message: "Failed to parse MI mediaStats"))
     }
-    
+
     let filteredArray = array.filter { $0["type"] as? String == "remote-inbound-rtp" }
     guard let firstItem = filteredArray.first,
           let roundTripTime = firstItem["roundTripTime"] as? Double,
           let packetsLost = firstItem["packetsLost"] as? Int else {
         return .failure(PagecallError.other(message: "Required data missing"))
     }
-    
+
     return .success(Stat(roundTripTime: roundTripTime * 1000.0, packetsLost: packetsLost))
 }
 

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -431,6 +431,11 @@ extension PagecallWebView: WKNavigationDelegate {
         })
     }
 
+    public static func configure() {
+        // Trigger instantiation
+        _ = CallManager.shared
+    }
+
     private func initializePageContext() {
         listenJavascriptMessages()
 

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -231,21 +231,15 @@ window["\(self.subscriptionsStorageName)"]["\(id)"]?.unsubscribe();
     }
 
     private var cleanups: [() -> Void] = []
-    private func cleanupPagecallContext() {
+    public func cleanup() {
         cleanups.forEach { cleanup in
             cleanup()
         }
         cleanups = []
     }
 
-    open override func didMoveToSuperview() {
-        if superview == nil {
-            cleanupPagecallContext()
-        }
-    }
-
     deinit {
-        cleanupPagecallContext()
+        cleanup()
     }
 
     public func sendMessage(message: String, completionHandler: ((Error?) -> Void)?) {
@@ -313,7 +307,7 @@ extension PagecallWebView {
         }
         let result = super.load(request)
         cleanups.append({
-            super.load(URLRequest(url: URL(string:"about:blank")!))
+            super.load(URLRequest(url: URL(string: "about:blank")!))
         })
         return result
     }
@@ -475,16 +469,16 @@ extension PagecallWebView: WKNavigationDelegate {
         PagecallLogger.shared.addBreadcrumb(message: "Navigated to \(webView.url?.absoluteString ?? "(blank)")")
 
         if let isPagecallMeeting = webView.url?.absoluteString.contains(PagecallMode.meet.baseURLString()), isPagecallMeeting {
-            cleanupPagecallContext()
+            cleanup()
             initializePageContext()
         } else if let isPagecallReplay = webView.url?.absoluteString.contains(PagecallMode.replay.baseURLString()), isPagecallReplay {
-            cleanupPagecallContext()
+            cleanup()
             listenJavascriptMessages()
         }
     }
 
     open func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        cleanupPagecallContext()
+        cleanup()
     }
 
     private func handleFatalError(_ error: Error) {

--- a/examples/uikit/UIKit Example/AppDelegate.swift
+++ b/examples/uikit/UIKit Example/AppDelegate.swift
@@ -6,12 +6,13 @@
 //
 
 import UIKit
+import Pagecall
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        PagecallWebView.configure()
         return true
     }
 

--- a/examples/uikit/UIKit Example/PagecallViewController.swift
+++ b/examples/uikit/UIKit Example/PagecallViewController.swift
@@ -92,6 +92,7 @@ class PagecallViewController: UIViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         loading.removeFromSuperview()
+        pagecallWebView.cleanup()
     }
 
     func setUpNavigationBar() {


### PR DESCRIPTION
- In some environments such as React Native, there were cases where `PagecallWebView` was reused after its superview became nil. To handle these cases properly, the cleanup function will not be called automatically. Instead, we expose a function to manually call cleanup.
- There was an issue where `CXStartCallAction` could not be processed correctly on the first run after installation. This PR resolves the issue by pre-initializing CallKit-related resources when the app launches.

*Be aware that all apps, including [react-native-pagecall](https://github.com/pagecall/react-native-pagecall) and [flutter_pagecall](https://github.com/pagecall/flutter_pagecall), must be updated to appropriately call the `cleanup` method and the `configure` static method.*