### PR TITLE
Fix load error and unintended persisted session

### DIFF
--- a/Pagecall.podspec
+++ b/Pagecall.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Pagecall'
-  s.version          = '0.0.24' # Update `version` field of PagecallWebView as you change this
+  s.version          = '0.0.25' # Update `version` field of PagecallWebView as you change this
   s.summary          = 'Pagecall WebView: Enhanced Voice Communication via Custom WebView based on WKWebView'
 
 # This description is used to generate tags and improve search results.

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -235,6 +235,7 @@ window["\(self.subscriptionsStorageName)"]["\(id)"]?.unsubscribe();
         cleanups.forEach { cleanup in
             cleanup()
         }
+        evaluateJavascriptWithLog(script: "window.Pagecall?.terminate()")
         cleanups = []
     }
 
@@ -321,11 +322,7 @@ extension PagecallWebView {
                 print("[PagecallWebView] a non-pagecall url is loaded")
             }
         }
-        let result = super.load(request)
-        cleanups.append({
-            super.load(URLRequest(url: URL(string: "about:blank")!))
-        })
-        return result
+        return super.load(request)
     }
 
     @available(*, deprecated, message: "Please use load(roomId) instead")

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -68,7 +68,7 @@ extension WKWebView {
 }
 
 open class PagecallWebView: WKWebView {
-    static let version = "0.0.24"
+    static let version = "0.0.25"
 
     var nativeBridge: NativeBridge?
     var controllerName = "pagecall"

--- a/examples/uikit/Podfile.lock
+++ b/examples/uikit/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Pagecall (0.0.23)
-  - Pagecall/Log (0.0.23):
+  - Pagecall (0.0.25)
+  - Pagecall/Log (0.0.25):
     - Sentry (~> 8.41.0)
   - Sentry (8.41.0):
     - Sentry/Core (= 8.41.0)
@@ -19,9 +19,9 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Pagecall: 34ec6b5553c66beac100cd74b5c9b919ae7dbbad
+  Pagecall: 6c9d4089f9b82ca240ff51e10c2b619fddd5f7c4
   Sentry: 54d0fe6c0df448497c8ed4cce66ccf7027e1823e
 
 PODFILE CHECKSUM: 2c5df6556b2906df5c2e3bf0debd55c824a18815
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2


### PR DESCRIPTION
- Fix error of `PagecallWebView.load(roomId: String, mode: PagecallMode, queryItems: [URLQueryItem])`
- Fix error of a persisted session after cleanup
- Release 0.0.25