### PR TITLE
feat: pagecallWillNavigate

### DIFF
--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -21,6 +21,10 @@ public protocol PagecallDelegate: AnyObject {
      */
     func pagecallDidReceive(_ view: PagecallWebView, event: [String: Any])
     func pagecall(_ view: PagecallWebView, requestDownloadFor url: URL)
+    /**
+     Called before navigation occurs in the web view
+     */
+    func pagecallWillNavigate(_ view: PagecallWebView, url: String)
 }
 
 // Optional delegates
@@ -30,6 +34,7 @@ public extension PagecallDelegate {
     func pagecallDidReceive(_ view: PagecallWebView, message: String) {}
     func pagecallDidReceive(_ view: PagecallWebView, event: [String: Any]) {}
     func pagecall(_ view: PagecallWebView, requestDownloadFor url: URL) {}
+    func pagecallWillNavigate(_ view: PagecallWebView, url: String) {}
 }
 
 public enum PagecallMode {
@@ -445,6 +450,9 @@ extension PagecallWebView: WKNavigationDelegate {
         }
 
         if let urlString = navigationAction.request.url?.absoluteString, urlString.starts(with: "http") {
+            if navigationAction.targetFrame?.isMainFrame == true {
+                delegate?.pagecallWillNavigate(self, url: urlString)
+            }
             decisionHandler(.allow)
 
             cleanup()

--- a/examples/uikit/UIKit Example/PagecallViewController.swift
+++ b/examples/uikit/UIKit Example/PagecallViewController.swift
@@ -202,6 +202,11 @@ extension PagecallViewController: PagecallDelegate {
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1) {
             self.loading.isHidden = true
         }
+        
+    }
+
+    func pagecallWillNavigate(_ view: PagecallWebView, url: String) {
+        print("pagecallWillNavigate: \(url)")
     }
 
 }


### PR DESCRIPTION
Detect URL changes within the webview.
This is intended for special cases where a URL other than `app.pagecall.com` needs to be rendered.