### PR TITLE
Fix bridge issues with multiple frames and support preview mode

### DIFF
--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -80,7 +80,7 @@ class NativeBridge: Equatable, ScriptDelegate {
     public let id: Int
 
     private let webview: PagecallWebView
-    private let frame: WKFrameInfo
+    let frame: WKFrameInfo
 
     private let emitter = WebViewEmitter()
 

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -49,7 +49,7 @@ class NativeBridge: Equatable, ScriptDelegate {
         didSet {
             AudioSessionManager.shared.stopHandlingInterruption()
 
-            if let mediaController = mediaController {
+            if let _ = mediaController {
                 synchronizePauseState()
 
                 // MI에서는 default일 경우 에어팟 연결이 해제된다.
@@ -287,17 +287,8 @@ class NativeBridge: Equatable, ScriptDelegate {
             self.disconnect()
             respond(nil, nil)
         case .setAudioDevice:
-            guard let mediaController = mediaController else {
-                respond(PagecallError.other(message: "Missing mediaController, initialize first"), nil)
-                return
-            }
-            struct DeviceId: Codable {
-                var deviceId: String
-            }
-            guard let payloadData = payloadData, let deviceId = try? JSONDecoder().decode(DeviceId.self, from: payloadData) else {
-                respond(PagecallError.other(message: "Invalid payload"), nil)
-                return
-            }
+            // Deprecated
+            respond(nil, nil)
         case .consume:
             guard let mediaController = mediaController else {
                 respond(PagecallError.other(message: "Missing mediaController, initialize first"), nil)

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -81,8 +81,6 @@ open class PagecallWebView: WKWebView {
         }
     }
 
-
-
     @available(*, unavailable)
     required public init?(coder: NSCoder) {
         fatalError("PagecallWebView cannot be instantiated from a storyboard")
@@ -623,7 +621,7 @@ extension PagecallWebView: UIPencilInteractionDelegate {
 extension PagecallWebView: PenGestureRecognizerDelegate {
     func didTouchesChange(_ touches: [UITouch], phase: TouchPhase) {
         guard useNativePenEvent else { return }
-        
+
         let locations = touches.map { touch in
             touch.preciseLocation(in: self)
         }

--- a/Sources/PagecallSDK/PenGestureRecognizer.swift
+++ b/Sources/PagecallSDK/PenGestureRecognizer.swift
@@ -1,5 +1,3 @@
-
-
 import UIKit
 
 enum TouchPhase: Int {
@@ -13,26 +11,39 @@ protocol PenGestureRecognizerDelegate: AnyObject {
     func didTouchesChange(_ touches: [UITouch], phase: TouchPhase)
 }
 
-class PenGestureRecognizer: UIGestureRecognizer {
+class PenGestureRecognizer: UIGestureRecognizer, UIGestureRecognizerDelegate {
     weak var eventDelegate: PenGestureRecognizerDelegate?
-    
+
+    override init(target: Any?, action: Selector?) {
+        super.init(target: target, action: action)
+        delegate = self
+    }
+
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
         eventDelegate?.didTouchesChange(Array(touches), phase: .began)
     }
-    
+
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesMoved(touches, with: event)
         eventDelegate?.didTouchesChange(Array(touches), phase: .moved)
     }
-    
+
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesEnded(touches, with: event)
         eventDelegate?.didTouchesChange(Array(touches), phase: .ended)
     }
-    
+
     override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesCancelled(touches, with: event)
         eventDelegate?.didTouchesChange(Array(touches), phase: .cancelled)
     }
-} 
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+}

--- a/examples/uikit/Podfile.lock
+++ b/examples/uikit/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Pagecall (0.0.25)
-  - Pagecall/Log (0.0.25):
+  - Pagecall (0.0.28)
+  - Pagecall/Log (0.0.28):
     - Sentry (~> 8.41.0)
   - Sentry (8.41.0):
     - Sentry/Core (= 8.41.0)
@@ -19,9 +19,9 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Pagecall: 6c9d4089f9b82ca240ff51e10c2b619fddd5f7c4
+  Pagecall: 9289cdbd522e03f273a598f051516bcf27feef82
   Sentry: 54d0fe6c0df448497c8ed4cce66ccf7027e1823e
 
 PODFILE CHECKSUM: 2c5df6556b2906df5c2e3bf0debd55c824a18815
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
- Fix an issue where the bridge was unintentionally destroyed when multiple frames existed besides the main frame.
- Support preview mode as well, which previously didn’t initialize the bridge due to no audio usage — but is now needed for use cases like `useNativePenEvent`.
- Resolve a bug where PagecallWebView became non-interactive when using useNativePenEvent.