### PR TITLE
Support `pagecallDidLoseAudioSession`

### DIFF
--- a/Pagecall.podspec
+++ b/Pagecall.podspec
@@ -11,12 +11,6 @@ Pod::Spec.new do |s|
   s.version          = '0.0.29' # Update `version` field of PagecallWebView as you change this
   s.summary          = 'Pagecall WebView: Enhanced Voice Communication via Custom WebView based on WKWebView'
 
-# This description is used to generate tags and improve search results.
-#   * Think: What does it do? Why did you write it? What is the focus?
-#   * Try to keep it short, snappy and to the point.
-#   * Write the description between the DESC delimiters below.
-#   * Finally, don't worry about the indent, CocoaPods strips it!
-
   s.description      = 'Pagecall-ios-sdk provides PagecallWebView, a custom WebView based on WKWebView that extends its functionality by adding a proprietary JavaScript Bridge to improve voice communication features. This enables customers to offer an enhanced voice communication experience. By utilizing PagecallWebView, powerful voice communication features can be easily integrated in place of the existing WKWebView.'
 
   s.homepage         = 'https://github.com/pagecall/pagecall-ios-sdk'
@@ -36,6 +30,7 @@ Pod::Spec.new do |s|
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
 
+  s.dependency 'RxSwift', '6.9.0'
   s.default_subspec = :none
 
   s.subspec 'Log' do |subspec|

--- a/Pagecall.podspec
+++ b/Pagecall.podspec
@@ -34,6 +34,6 @@ Pod::Spec.new do |s|
   s.default_subspec = :none
 
   s.subspec 'Log' do |subspec|
-    subspec.dependency 'Sentry', '~> 8.41.0'
+    subspec.dependency 'Sentry', '~> 8.46.0'
   end
 end

--- a/Sources/PagecallSDK/AudioSessionManager.swift
+++ b/Sources/PagecallSDK/AudioSessionManager.swift
@@ -27,6 +27,7 @@ class AudioSessionManager {
     private init() {
         NotificationCenter.default.addObserver(self, selector: #selector(handleRouteChange), name: AVAudioSession.routeChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleInterruption), name: AVAudioSession.interruptionNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleMediaServicesReset), name: AVAudioSession.mediaServicesWereResetNotification, object: nil)
     }
 
     deinit {
@@ -155,6 +156,15 @@ class AudioSessionManager {
         print("[AudioSessionManager] interrupt", interruptionDetail)
         guard let payload = try? JSONSerialization.data(withJSONObject: interruptionDetail, options: .withoutEscapingSlashes) else { return }
         self.emitter?.emit(eventName: .audioSessionInterrupted, data: payload)
+    }
+
+    @objc private func handleMediaServicesReset(notification: Notification) {
+        self.emitter?.log(name: "AVAudioSession", message: "MediaServicesReset notification name=\(notification.name)")
+
+        let detail = notification.userInfo as? [String: Any] ?? [String: Any]()
+        print("[AudioSessionManager] mediaServicesWereReset", detail)
+        guard let payload = try? JSONSerialization.data(withJSONObject: detail, options: .withoutEscapingSlashes) else { return }
+        self.emitter?.emit(eventName: .mediaServicesReset, data: payload)
     }
 }
 

--- a/Sources/PagecallSDK/AudioSessionManager.swift
+++ b/Sources/PagecallSDK/AudioSessionManager.swift
@@ -25,6 +25,10 @@ class AudioSessionManager {
     }
 
     private init() {
+        if #available(iOS 14.5, *) {
+            try? AVAudioSession().setPrefersNoInterruptionsFromSystemAlerts(true)
+        }
+
         NotificationCenter.default.addObserver(self, selector: #selector(handleRouteChange), name: AVAudioSession.routeChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleInterruption), name: AVAudioSession.interruptionNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleMediaServicesReset), name: AVAudioSession.mediaServicesWereResetNotification, object: nil)

--- a/Sources/PagecallSDK/CallManager.swift
+++ b/Sources/PagecallSDK/CallManager.swift
@@ -136,6 +136,7 @@ public class CallManager: NSObject, CXProviderDelegate {
 
     public func provider(_ provider: CXProvider, perform action: CXStartCallAction) {
         print("[CallManager] providerPerformStartCall", action)
+        CallManager.emitter?.log(name: "CallManager", message: "performStartCall")
 
         if let _ = self.callId {
             print("[CallManager] providerPerformStartCall: unexpected callId")
@@ -158,6 +159,7 @@ public class CallManager: NSObject, CXProviderDelegate {
 
     public func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         print("[CallManager] providerPerformEndCall", action)
+        CallManager.emitter?.log(name: "CallManager", message: "performEndCall")
 
         if self.callId != action.callUUID {
             print("[CallManager] providerPerformStartCall: unexpected callId")
@@ -177,29 +179,34 @@ public class CallManager: NSObject, CXProviderDelegate {
 
     public func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
         print("[CallManager] providerPerformSetHeldCall", action)
+        CallManager.emitter?.log(name: "CallManager", message: "performSetHeldCall")
         action.fulfill()
         self.delegate?.provider?(provider, perform: action)
     }
 
     public func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
         print("[CallManager] providerPerformSetMutedCall", action)
+        CallManager.emitter?.log(name: "CallManager", message: "performSetMutedCall")
         action.fulfill()
         self.delegate?.provider?(provider, perform: action)
     }
 
     public func provider(_ provider: CXProvider, perform action: CXSetGroupCallAction) {
         print("[CallManager] providerPerformSetGroupCall", action)
+        CallManager.emitter?.log(name: "CallManager", message: "performSetGroupCall")
         action.fulfill()
         self.delegate?.provider?(provider, perform: action)
     }
 
     public func provider(_ provider: CXProvider, timedOutPerforming action: CXAction) {
         print("[CallManager] providerTimedOutPerforming", action)
+        CallManager.emitter?.log(name: "CallManager", message: "timedOutPerforming: \(action.description)")
         self.delegate?.provider?(provider, timedOutPerforming: action)
     }
 
     public func provider(_ provider: CXProvider, didActivate audioSession: AVAudioSession) {
         print("[CallManager] providerDidActivate")
+        CallManager.emitter?.log(name: "CallManager", message: "didActivateAudioSession")
         /**
          If there is an existing `VolumeRecorder` at this point, it may be stuck in a broken state and keep reporting a power of -120.
          Destroy the instance to allow creating a new one.
@@ -210,6 +217,7 @@ public class CallManager: NSObject, CXProviderDelegate {
 
     public func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
         print("[CallManager] providerDidDeactivate")
+        CallManager.emitter?.log(name: "CallManager", message: "didDeactivateAudioSession")
         self.delegate?.provider?(provider, didDeactivate: audioSession)
     }
 }

--- a/Sources/PagecallSDK/CallManager.swift
+++ b/Sources/PagecallSDK/CallManager.swift
@@ -1,5 +1,6 @@
 import CallKit
 import AVFoundation
+import Combine
 
 public class CallManager: NSObject, CXProviderDelegate {
     static public let shared = CallManager()
@@ -9,6 +10,14 @@ public class CallManager: NSObject, CXProviderDelegate {
     let callController: CXCallController
     public var delegate: CXProviderDelegate?
 
+    private let callState = CurrentValueSubject<CallState, Never>(
+        CallState(shouldBeInCall: false, isInCall: false, error: nil)
+    )
+
+    private var cancellables = Set<AnyCancellable>()
+
+    private var callId: UUID?
+
     private override init() {
         print("[CallManager] init")
         let configuration = CXProviderConfiguration()
@@ -17,64 +26,96 @@ public class CallManager: NSObject, CXProviderDelegate {
         callController = CXCallController()
         super.init()
         provider.setDelegate(self, queue: nil)
-    }
 
-    private var callId: UUID?
+        callState
+            .filter({ callState in callState.shouldBeInCall != callState.isInCall })
+            .flatMap(maxPublishers: .max(1)) { callState -> AnyPublisher<CallState, Never> in
+                let shouldBeInCall = callState.shouldBeInCall
+            return Future<CallState, Never> { [weak self] promise in
+                if let callId = self?.callId {
+                    if shouldBeInCall {
+                        promise(
+                            .success(.init(shouldBeInCall: true, isInCall: true, error: nil))
+                        )
+                    } else {
+                        // end the call
+                        self?.callController.requestTransaction(with: [CXEndCallAction(call: callId)]) { error in
+                            if let error = error {
+                                self?.provider.reportCall(with: callId, endedAt: Date(), reason: .failed)
+                                promise(
+                                    .success(.init(shouldBeInCall: false, isInCall: false, error: error))
+                                )
+                            } else {
+                                self?.provider.reportCall(with: callId, endedAt: Date(), reason: .remoteEnded)
+                                promise(
+                                    .success(.init(shouldBeInCall: false, isInCall: false, error: nil))
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    if shouldBeInCall {
+                        // start a new call
+                        let newCallId = UUID()
+                        self?.provider.reportOutgoingCall(with: newCallId, startedConnectingAt: Date())
+                        self?.callController.requestTransaction(with: [CXStartCallAction(call: newCallId, handle: CXHandle(type: .generic, value: "Pagecall"))]) { error in
+                            if let error = error {
+                                self?.provider.reportCall(with: newCallId, endedAt: Date(), reason: .failed)
+                                promise(
+                                    .success(.init(shouldBeInCall: true, isInCall: false, error: error))
+                                )
+                                return
+                            }
+                            self?.provider.reportOutgoingCall(with: newCallId, connectedAt: Date())
+                            promise(
+                                .success(.init(shouldBeInCall: true, isInCall: true, error: nil))
+                            )
+                        }
+                    } else {
+                        promise(
+                            .success(.init(shouldBeInCall: false, isInCall: false, error: nil))
+                        )
+                    }
+                }
+            }
+            .eraseToAnyPublisher()
+          }
+          .sink { [weak self] value in
+            self?.callState.send(value)
+          }
+          .store(in: &cancellables)
+    }
 
     static weak var emitter: WebViewEmitter?
 
     func startCall(completion: @escaping (Error?) -> Void) {
-        PagecallLogger.shared.addBreadcrumb(message: "startCall")
-
-        if let _ = callId {
-            completion(PagecallError.other(message: "Call not ended"))
-            return
-        }
-
         if CallManager.disabled {
             PagecallLogger.shared.addBreadcrumb(message: "startCall skipped")
             completion(nil)
             return
         }
 
-        let callId = UUID()
-        self.callId = callId
-        provider.reportOutgoingCall(with: callId, startedConnectingAt: Date())
-        callController.requestTransaction(with: [CXStartCallAction(call: callId, handle: CXHandle(type: .generic, value: "Pagecall"))]) { error in
-            if self.callId != callId {
-                self.provider.reportCall(with: callId, endedAt: Date(), reason: .failed)
-                completion(error ?? PagecallError.other(message: "startCall interrupted"))
-                return
-            }
-            if let error = error {
-                self.provider.reportCall(with: callId, endedAt: Date(), reason: .failed)
-                self.callId = nil
-                completion(error)
-                return
-            }
-            self.provider.reportOutgoingCall(with: callId, connectedAt: Date())
+        PagecallLogger.shared.addBreadcrumb(message: "startCall")
 
-            completion(nil)
-        }
+        let current = callState.value
+        callState.send(.init(shouldBeInCall: true, isInCall: current.isInCall, error: nil))
+        callState
+            .filter { $0.shouldBeInCall && ($0.isInCall || $0.error != nil) }
+            .first()
+            .sink { state in completion(state.error) }
+            .store(in: &cancellables)
     }
 
     func endCall(completion: @escaping (Error?) -> Void) {
         PagecallLogger.shared.addBreadcrumb(message: "endCall")
 
-        guard let callId = callId else {
-            completion(nil)
-            return
-        }
-        self.callId = nil
-        callController.requestTransaction(with: [CXEndCallAction(call: callId)]) { error in
-            if let error = error {
-                self.provider.reportCall(with: callId, endedAt: Date(), reason: .failed)
-                completion(error)
-            } else {
-                self.provider.reportCall(with: callId, endedAt: Date(), reason: .remoteEnded)
-                completion(nil)
-            }
-        }
+        let current = callState.value
+        callState.send(.init(shouldBeInCall: false, isInCall: current.isInCall, error: nil))
+        callState
+            .filter { !$0.shouldBeInCall && (!$0.isInCall || $0.error != nil) }
+            .first()
+            .sink { state in completion(state.error) }
+            .store(in: &cancellables)
     }
 
     // MARK: CXProviderDelegate
@@ -85,6 +126,11 @@ public class CallManager: NSObject, CXProviderDelegate {
 
     public func provider(_ provider: CXProvider, perform action: CXStartCallAction) {
         print("[CallManager] providerPerformStartCall", action)
+
+        if let _ = self.callId {
+            print("[CallManager] providerPerformStartCall: unexpected callId")
+        }
+        self.callId = action.callUUID
 
         // MI에서는 default일 경우 에어팟 연결이 해제된다.
         AudioSessionManager.shared().emitter = CallManager.emitter
@@ -103,10 +149,20 @@ public class CallManager: NSObject, CXProviderDelegate {
     public func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         print("[CallManager] providerPerformEndCall", action)
 
+        if self.callId != action.callUUID {
+            print("[CallManager] providerPerformStartCall: unexpected callId")
+        }
+        self.callId = nil
+
         AudioSessionManager.clear()
 
         action.fulfill()
         self.delegate?.provider?(provider, perform: action)
+
+        let current = callState.value
+        callState.send(
+            .init(shouldBeInCall: current.shouldBeInCall, isInCall: false, error: nil)
+        )
     }
 
     public func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
@@ -146,4 +202,10 @@ public class CallManager: NSObject, CXProviderDelegate {
         print("[CallManager] providerDidDeactivate")
         self.delegate?.provider?(provider, didDeactivate: audioSession)
     }
+}
+
+struct CallState {
+    let shouldBeInCall: Bool
+    let isInCall: Bool
+    let error: Error?
 }

--- a/Sources/PagecallSDK/CallManager.swift
+++ b/Sources/PagecallSDK/CallManager.swift
@@ -10,6 +10,7 @@ public class CallManager: NSObject, CXProviderDelegate {
     public var delegate: CXProviderDelegate?
 
     private override init() {
+        print("[CallManager] init")
         let configuration = CXProviderConfiguration()
         configuration.supportedHandleTypes = [.generic]
         provider = CXProvider(configuration: configuration)

--- a/Sources/PagecallSDK/CallManager.swift
+++ b/Sources/PagecallSDK/CallManager.swift
@@ -9,6 +9,7 @@ public class CallManager: NSObject, CXProviderDelegate {
     private let provider: CXProvider
     private let callController: CXCallController
     public var delegate: CXProviderDelegate?
+    public var callDelegate: PagecallCallDelegate?
 
     private let callState = CurrentValueSubject<CallState, Never>(
         CallState(shouldBeInCall: false, isInCall: false, error: nil)
@@ -222,11 +223,13 @@ public class CallManager: NSObject, CXProviderDelegate {
     public func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
         print("[CallManager] providerDidDeactivate")
         CallManager.emitter?.log(name: "CallManager", message: "didDeactivateAudioSession")
+        CallManager.emitter?.error(name: "CallError", message: "audioSession deactivated")
 
         audioSessionManager?.dispose()
         audioSessionManager = nil
 
         self.delegate?.provider?(provider, didDeactivate: audioSession)
+        self.callDelegate?.didDeactivate()
     }
 }
 
@@ -234,4 +237,8 @@ struct CallState {
     let shouldBeInCall: Bool
     let isInCall: Bool
     let error: Error?
+}
+
+public protocol PagecallCallDelegate: AnyObject {
+    func didDeactivate()
 }

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -121,8 +121,6 @@ class NativeBridge: Equatable, ScriptDelegate {
         }
     }
 
-    private var isCallStarted = false
-
     func messageHandler(message: String) {
         let data = message.data(using: .utf8)!
         guard let jsonArray = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
@@ -184,7 +182,6 @@ class NativeBridge: Equatable, ScriptDelegate {
                         PagecallLogger.shared.capture(error: error)
                     } else {
                         print("[NativeBridge] startCall success")
-                        self.isCallStarted = true
                     }
                     // Continue anyway
                     do {
@@ -351,16 +348,13 @@ class NativeBridge: Equatable, ScriptDelegate {
         miController?.dispose()
         miController = nil
 
-        if isCallStarted {
-            CallManager.shared.endCall { error in
-                self.isCallStarted = false
-                if let error = error {
-                    print("[PagecallWebView] endCall failure")
-                    self.emitter.error(name: "EndCallError", message: error.localizedDescription)
-                    PagecallLogger.shared.capture(error: error)
-                } else {
-                    print("[PagecallWebView] endCall success")
-                }
+        CallManager.shared.endCall { error in
+            if let error = error {
+                print("[PagecallWebView] endCall failure")
+                self.emitter.error(name: "EndCallError", message: error.localizedDescription)
+                PagecallLogger.shared.capture(error: error)
+            } else {
+                print("[PagecallWebView] endCall success")
             }
         }
     }

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -7,7 +7,8 @@ struct Stat: Encodable {
 }
 
 enum BridgeEvent: String, Codable {
-    case audioDevice, audioDevices, audioStatus, audioSessionRouteChanged, audioSessionInterrupted, mediaStat, audioEnded, videoEnded, screenshareEnded, connected, disconnected, log, error
+    case audioDevice, audioDevices, audioStatus, mediaStat, audioEnded, videoEnded, screenshareEnded, connected, disconnected, log, error
+    case audioSessionRouteChanged, audioSessionInterrupted, mediaServicesReset
     case connectTransport, penTouch
 }
 

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -273,20 +273,11 @@ class NativeBridge: Equatable, ScriptDelegate {
                     respond(PagecallError.other(message: "Failed to encode volume"), nil)
                 }
             }
-            do {
-                let volumeRecorder = try VolumeRecorder.shared()
-                respondVolumeWithPower(volumeRecorder.averagePower())
-            } catch {
-                if let error = error as? PagecallError {
-                    switch error {
-                    case .missingAudioPermission:
-                        respondVolumeWithPower(-160)
-                        return
-                    default:
-                        break
-                    }
-                }
-                respond(error, nil)
+            if let averagePower = CallManager.shared.averagePower() {
+                respondVolumeWithPower(averagePower)
+            } else {
+                respondVolumeWithPower(-160)
+
             }
         case .pauseAudio:
             isAudioPaused = true
@@ -362,7 +353,6 @@ class NativeBridge: Equatable, ScriptDelegate {
 
     deinit {
         disconnect()
-        VolumeRecorder.clear()
     }
 }
 

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -7,6 +7,7 @@ public enum TerminationReason {
 
 public protocol PagecallDelegate: AnyObject {
     func pagecallDidTerminate(_ view: PagecallWebView, reason: TerminationReason)
+    func pagecallDidLoseAudioSession()
     func pagecallDidEncounter(_ view: PagecallWebView, error: Error)
     func pagecallDidLoad(_ view: PagecallWebView)
     /**
@@ -155,6 +156,8 @@ open class PagecallWebView: WKWebView {
             self.pencilDebugOverlay = pencilDebugOverlay
             window.addSubview(pencilDebugOverlay)
         }
+
+        CallManager.shared.callDelegate = self
     }
 
     public override var customUserAgent: String? {
@@ -623,5 +626,11 @@ extension PagecallWebView: PenGestureRecognizerDelegate {
             touch.preciseLocation(in: self)
         }
         nativeBridge?.emitPenTouch(points: locations, phase: phase)
+    }
+}
+
+extension PagecallWebView: PagecallCallDelegate {
+    public func didDeactivate() {
+        self.delegate?.pagecallDidLoseAudioSession()
     }
 }

--- a/Sources/PagecallSDK/VolumeRecorder.swift
+++ b/Sources/PagecallSDK/VolumeRecorder.swift
@@ -3,28 +3,11 @@ import AVFoundation
 class VolumeRecorder {
     private let audioRecorder: AVAudioRecorder
 
-    private static var instance: VolumeRecorder?
-
-    static func shared() throws -> VolumeRecorder {
-        if let instance = instance {
-            return instance
-        } else if let isAudioAuthorized = DeviceManager.getAuthorizationStatusAsBool(for: .audio), isAudioAuthorized {
-            let newInstance = try VolumeRecorder()
-            instance = newInstance
-            return newInstance
-        } else {
-            throw PagecallError.missingAudioPermission
-        }
+    func destroy() {
+        audioRecorder.stop()
     }
 
-    static func clear() {
-        if let instance = instance {
-            instance.audioRecorder.stop()
-            self.instance = nil
-        }
-    }
-
-    private init() throws {
+    init(_ _: AudioSessionManager) throws {
         let documentPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let audioFilename = documentPath.appendingPathComponent("nothing.m4a")
         let settings = [
@@ -50,8 +33,6 @@ class VolumeRecorder {
 
         return perceptual
     }
-
-    var unusualAveragePowerCount = 0
 
     func averagePower() -> Float {
         audioRecorder.updateMeters()

--- a/examples/uikit/Podfile.lock
+++ b/examples/uikit/Podfile.lock
@@ -1,7 +1,10 @@
 PODS:
-  - Pagecall (0.0.28)
-  - Pagecall/Log (0.0.28):
+  - Pagecall (0.0.29):
+    - RxSwift (= 6.9.0)
+  - Pagecall/Log (0.0.29):
+    - RxSwift (= 6.9.0)
     - Sentry (~> 8.41.0)
+  - RxSwift (6.9.0)
   - Sentry (8.41.0):
     - Sentry/Core (= 8.41.0)
   - Sentry/Core (8.41.0)
@@ -12,6 +15,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - RxSwift
     - Sentry
 
 EXTERNAL SOURCES:
@@ -19,7 +23,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Pagecall: 9289cdbd522e03f273a598f051516bcf27feef82
+  Pagecall: 34a00bf7042cfc94ca7bb0f2f085aa5fb1305f3d
+  RxSwift: 31649ace6aceeb422e16ff71c60804f9c3281ed9
   Sentry: 54d0fe6c0df448497c8ed4cce66ccf7027e1823e
 
 PODFILE CHECKSUM: 2c5df6556b2906df5c2e3bf0debd55c824a18815

--- a/examples/uikit/Podfile.lock
+++ b/examples/uikit/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Pagecall (0.0.29):
+  - Pagecall (0.0.29-dev.5):
     - RxSwift (= 6.9.0)
-  - Pagecall/Log (0.0.29):
+  - Pagecall/Log (0.0.29-dev.5):
     - RxSwift (= 6.9.0)
-    - Sentry (~> 8.41.0)
+    - Sentry (~> 8.46.0)
   - RxSwift (6.9.0)
-  - Sentry (8.41.0):
-    - Sentry/Core (= 8.41.0)
-  - Sentry/Core (8.41.0)
+  - Sentry (8.46.0):
+    - Sentry/Core (= 8.46.0)
+  - Sentry/Core (8.46.0)
 
 DEPENDENCIES:
   - Pagecall (from `../../`)
@@ -23,9 +23,9 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Pagecall: 34a00bf7042cfc94ca7bb0f2f085aa5fb1305f3d
+  Pagecall: 69e6d63d8a1458da4a37c296f1e134fda478dddb
   RxSwift: 31649ace6aceeb422e16ff71c60804f9c3281ed9
-  Sentry: 54d0fe6c0df448497c8ed4cce66ccf7027e1823e
+  Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
 
 PODFILE CHECKSUM: 2c5df6556b2906df5c2e3bf0debd55c824a18815
 

--- a/examples/uikit/UIKit Example/PagecallViewController.swift
+++ b/examples/uikit/UIKit Example/PagecallViewController.swift
@@ -178,6 +178,12 @@ class PagecallViewController: UIViewController {
 }
 
 extension PagecallViewController: PagecallDelegate {
+    func pagecallDidLoseAudioSession() {
+        onFatalError?(
+            PagecallError.other(message: "Call interrupted")
+        )
+    }
+
     func pagecallDidTerminate(_ view: Pagecall.PagecallWebView, reason: Pagecall.TerminationReason) {
         loading.setProgress(progress: 1.0)
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1) {


### PR DESCRIPTION
When CallKit becomes deactivated — for example, due to an incoming call or Screen Time being triggered — we observed that the app can enter a state where audio session recovery becomes impossible despite multiple internal attempts. In this state, audio transmission and reception no longer function.

To address this, we’ve added the `pagecallDidLoseAudioSession` delegate to expose this situation. When triggered, the app should display an appropriate alert and guide the user to leave and re-enter the meeting room.