### PR TITLE
Keep call on network reconnection

### DIFF
--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -339,20 +339,19 @@ class NativeBridge: Equatable, ScriptDelegate {
     public func disconnect() {
         miController?.dispose()
         miController = nil
+    }
 
+    deinit {
+        disconnect()
         CallManager.shared.endCall { error in
             if let error = error {
                 print("[PagecallWebView] endCall failure")
-                self.emitter.error(name: "EndCallError", message: error.localizedDescription)
                 PagecallLogger.shared.capture(error: error)
             } else {
                 print("[PagecallWebView] endCall success")
             }
         }
-    }
 
-    deinit {
-        disconnect()
     }
 }
 

--- a/examples/uikit/UIKit Example/PagecallViewController.swift
+++ b/examples/uikit/UIKit Example/PagecallViewController.swift
@@ -179,9 +179,11 @@ class PagecallViewController: UIViewController {
 
 extension PagecallViewController: PagecallDelegate {
     func pagecallDidLoseAudioSession() {
-        onFatalError?(
-            PagecallError.other(message: "Call interrupted")
-        )
+        messageBox.setText(message: "Call interrupted")
+        messageBox.isHidden = false
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 3) {
+            self.messageBox.isHidden = true
+        }
     }
 
     func pagecallDidTerminate(_ view: Pagecall.PagecallWebView, reason: Pagecall.TerminationReason) {


### PR DESCRIPTION
It was observed that `pagecallDidLoseAudioSession`, which was added in #96, was also being triggered during media reconnection caused by network reconnection. This happens because the CallKit call state is deactivated and then reactivated during media reconnection. The call state is now maintained until exit (i.e., destruction of the NativeBridge).