### PR TITLE
Fix retained WKWebView instance after call

### DIFF
--- a/Pagecall.podspec
+++ b/Pagecall.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Pagecall'
-  s.version          = '0.0.30' # Update `version` field of PagecallWebView as you change this
+  s.version          = '0.0.31' # Update `version` field of PagecallWebView as you change this
   s.summary          = 'Pagecall WebView: Enhanced Voice Communication via Custom WebView based on WKWebView'
 
   s.description      = 'Pagecall-ios-sdk provides PagecallWebView, a custom WebView based on WKWebView that extends its functionality by adding a proprietary JavaScript Bridge to improve voice communication features. This enables customers to offer an enhanced voice communication experience. By utilizing PagecallWebView, powerful voice communication features can be easily integrated in place of the existing WKWebView.'

--- a/Sources/PagecallSDK/CallManager.swift
+++ b/Sources/PagecallSDK/CallManager.swift
@@ -62,6 +62,7 @@ public class CallManager: NSObject, CXProviderDelegate {
                         self?.callController.requestTransaction(with: [CXStartCallAction(call: newCallId, handle: CXHandle(type: .generic, value: "Pagecall"))]) { error in
                             if let error = error {
                                 self?.provider.reportCall(with: newCallId, endedAt: Date(), reason: .failed)
+                                CallManager.emitter?.error(name: "CallManager", message: "Start call error: \(error.localizedDescription)")
                                 promise(
                                     .success(.init(shouldBeInCall: true, isInCall: false, error: error))
                                 )

--- a/Sources/PagecallSDK/CallManager.swift
+++ b/Sources/PagecallSDK/CallManager.swift
@@ -9,7 +9,7 @@ public class CallManager: NSObject, CXProviderDelegate {
     private let provider: CXProvider
     private let callController: CXCallController
     public var delegate: CXProviderDelegate?
-    public var callDelegate: PagecallCallDelegate?
+    public weak var callDelegate: PagecallCallDelegate?
 
     private let callState = CurrentValueSubject<CallState, Never>(
         CallState(shouldBeInCall: false, isInCall: false, error: nil)

--- a/Sources/PagecallSDK/NativeBridge.swift
+++ b/Sources/PagecallSDK/NativeBridge.swift
@@ -63,8 +63,10 @@ class NativeBridge: Equatable, ScriptDelegate {
         let success = isAudioPaused ? miController.pauseAudio() : miController.resumeAudio()
         if success {
             emitter.log(name: "AudioStateChange", message: isAudioPaused ? "Paused" : "Resumed")
-        } else {
+        } else if miController.started {
             emitter.error(name: "AudioStateChangeError", message: isAudioPaused ? "Failed to pause" : "Failed to resume")
+        } else {
+            // Not producing yet
         }
     }
 

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -56,7 +56,7 @@ public enum PagecallMode {
 let debugPencil = false
 
 open class PagecallWebView: WKWebView {
-    static let version = "0.0.30"
+    static let version = "0.0.31"
 
     var nativeBridge: NativeBridge?
     var controllerName = "pagecall"


### PR DESCRIPTION
- Fixed an issue introduced in #96 where `CallManager` held a strong reference to `PagecallWebView` as its `callDelegate`, causing the web view instance to persist even after it was closed.
- Added an error log when startCall fails.
- Removed a misleading “Failed to resume” warning which was being logged even on successful entry.