### PR TITLE
fix(example): cleanup on deinit

### DIFF
--- a/examples/uikit/UIKit Example/PagecallViewController.swift
+++ b/examples/uikit/UIKit Example/PagecallViewController.swift
@@ -92,6 +92,9 @@ class PagecallViewController: UIViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         loading.removeFromSuperview()
+    }
+
+    deinit {
         pagecallWebView.cleanup()
     }
 


### PR DESCRIPTION
On some OS version, when the native camera is activated within a webview, `viewDidDisappear` called. 

This causes unwanted termination when `pagecallWebView.cleanup()` is called at that timing. 

We change the example code to call `pagecallWebView.cleanup()` under more robust conditions.