### PR TITLE
fix: import UIKit in CallManager for SPM source builds

### DIFF
--- a/Sources/PagecallSDK/CallManager.swift
+++ b/Sources/PagecallSDK/CallManager.swift
@@ -1,3 +1,4 @@
+import UIKit
 import CallKit
 import AVFoundation
 import Combine


### PR DESCRIPTION
## Problem
`Sources/PagecallSDK/CallManager.swift` references `UIApplication.didBecomeActiveNotification` but only imports `CallKit`, `AVFoundation`, and `Combine`.

This compiles fine via **CocoaPods** (which distributes a prebuilt binary framework), but **Swift Package Manager** builds the SDK from source and fails:

```
Swift Compiler Error: Cannot find 'UIApplication' in scope
Sources/PagecallSDK/CallManager.swift:90
```

## Fix
Add `import UIKit` to `CallManager.swift`. It is the only file on `main` that uses UIKit symbols without importing UIKit (the other UIKit-using sources already import UIKit/WebKit).

## Why this matters now
`flutter_pagecall` is adding iOS Swift Package Manager support (Flutter 3.44 warns that plugins without SPM support will eventually error). With SPM enabled, Flutter compiles `pagecall-ios-sdk` from source via the `PagecallCore` product, which surfaced this latent issue.

## Verification
Built the `flutter_pagecall` example app with SPM enabled (`flutter config --enable-swift-package-manager`, Flutter 3.44 stable). With this one-line change the app builds end-to-end: `✓ Built Runner.app`, linking the `PagecallCore` SPM product.

## Follow-up
After this merges, please cut a new release tag so `flutter_pagecall` can bump its `pagecall-ios-sdk` pin (currently `exact: "0.0.31"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)